### PR TITLE
Refine offline helix renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,11 @@
   <meta charset="utf-8">
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <meta name="color-scheme" content="light dark">
-  <style>
-    /* ND-safe presentation: calm contrast, generous spacing, zero motion */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9da0c5; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:16px 18px; border-bottom:1px solid #1d1d2a; }
-    header strong { letter-spacing:0.04em; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:20px auto; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 24px; color:var(--muted); padding:0 16px; text-align:center; }
   <meta name="color-scheme" content="dark light">
   <style>
-    /* ND-safe presentation: calm palette, high readability, no motion */
+    /* ND-safe: calm palette, no motion, ample contrast */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     h1 { margin:0; font-size:20px; letter-spacing:0.02em; }
     .status { color:var(--muted); font-size:12px; margin-top:4px; }
@@ -29,29 +19,6 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Preparing canvas…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static study of Vesica, Tree-of-Life, Fibonacci spiral, and double helix lattice. Open this file directly; no animation or external dependencies.</p>
-
-  <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
-
-    const status = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
-
-    if (!ctx) {
-      status.textContent = "Canvas unavailable; rendering skipped.";
-      throw new Error("Canvas context missing");
-    }
-
-    /**
-     * Attempt to load palette overrides from disk. The fetch call only touches
-     * the local file path; failures fall back to the baked-in palette so the
-     * render still completes offline.
     <h1>Cosmic Helix Renderer</h1>
     <div class="status" id="status">Preparing palette…</div>
   </header>
@@ -72,9 +39,9 @@
      */
     async function loadPalette(path) {
       try {
-        const response = await fetch(path, { cache: "no-store" });
+        const response = await fetch(path, { cache: 'no-store' });
         if (!response.ok) {
-          throw new Error("Palette not accessible");
+          throw new Error('Palette not accessible');
         }
         return await response.json();
       } catch (error) {
@@ -95,24 +62,16 @@
     });
 
     const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
+      bg: '#0b0b12',
+      ink: '#e8e8f0',
+      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
     };
 
-    const paletteData = await loadPalette("./data/palette.json");
+    const paletteData = await loadPalette('./data/palette.json');
     const palette = paletteData || fallbackPalette;
     status.textContent = paletteData
-      ? "Palette loaded from data/palette.json."
-      : "Palette missing or blocked; using ND-safe fallback.";
-
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette,
-      NUM
-    });
-    status.textContent = paletteData ? 'Palette loaded. Rendering static layers…' : 'Palette missing or blocked; using safe fallback.';
+      ? 'Palette loaded. Rendering static layers…'
+      : 'Palette missing or blocked; using safe fallback.';
 
     if (!ctx) {
       status.textContent = 'Canvas context unavailable in this browser.';

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,24 +1,24 @@
 /*
   helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry.
+  Static ND-safe renderer for layered sacred geometry.
 
-  Layer order is intentional to preserve calm depth:
-    1. Vesica field (grounding lattice of intersecting circles)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci spiral (phi-based curve for gentle motion cues without animation)
-    4. Double-helix lattice (mirrored strands with 144 sample points)
+  Layer sequence (outer to inner):
+    1. Vesica field
+    2. Tree-of-Life scaffold
+    3. Fibonacci curve
+    4. Double helix lattice
 
-  All helpers are pure and only depend on the arguments passed in.
-  This keeps edits deterministic and prevents accidental motion loops.
+  Each helper is a small pure function so edits remain deterministic and
+  append-only. No animation loops are introduced anywhere in this file.
 */
 
-const FALLBACK_PALETTE = Object.freeze({
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
+const DEFAULT_PALETTE = Object.freeze({
+  bg: '#0b0b12',
+  ink: '#e8e8f0',
+  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
 });
 
-const FALLBACK_NUM = Object.freeze({
+const DEFAULT_NUM = Object.freeze({
   THREE: 3,
   SEVEN: 7,
   NINE: 9,
@@ -29,33 +29,38 @@ const FALLBACK_NUM = Object.freeze({
   ONEFORTYFOUR: 144
 });
 
-export function renderHelix(ctx, options = {}) {
+export function renderHelix(ctx, config = {}) {
   if (!ctx) {
     return;
   }
 
-  const width = Number.isFinite(options.width) ? options.width : 1440;
-  const height = Number.isFinite(options.height) ? options.height : 900;
-  const palette = normalisePalette(options.palette);
-  const NUM = ensureNumerology(options.NUM);
+  const width = normaliseDimension(config.width, ctx.canvas.width || 1440);
+  const height = normaliseDimension(config.height, ctx.canvas.height || 900);
+  const palette = normalisePalette(config.palette);
+  const NUM = normaliseNumerology(config.NUM);
 
   ctx.save();
-  prepareCanvas(ctx, width, height, palette.bg);
+  configureContext(ctx);
+  ctx.canvas.width = width;
+  ctx.canvas.height = height;
+
+  fillBackground(ctx, width, height, palette.bg);
 
   drawVesicaField(ctx, { width, height, color: palette.layers[0], NUM });
   drawTreeOfLife(ctx, {
     width,
     height,
-    lineColor: palette.layers[1],
+    strokeColor: palette.layers[1],
     nodeColor: palette.ink,
+    haloColor: palette.layers[5],
     NUM
   });
   drawFibonacciCurve(ctx, { width, height, color: palette.layers[2], NUM });
   drawHelixLattice(ctx, {
     width,
     height,
-    strandA: palette.layers[3],
-    strandB: palette.layers[4],
+    strandAColor: palette.layers[3],
+    strandBColor: palette.layers[4],
     rungColor: palette.layers[5],
     NUM
   });
@@ -63,272 +68,97 @@ export function renderHelix(ctx, options = {}) {
   ctx.restore();
 }
 
+function normaliseDimension(value, fallback) {
+  if (Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  return fallback;
+}
+
 function normalisePalette(palette) {
   if (!palette || !Array.isArray(palette.layers)) {
-    return FALLBACK_PALETTE;
+    return DEFAULT_PALETTE;
   }
-  const layers = palette.layers.slice(0, FALLBACK_PALETTE.layers.length);
-  while (layers.length < FALLBACK_PALETTE.layers.length) {
-    layers.push(FALLBACK_PALETTE.layers[layers.length]);
+  const layers = palette.layers.slice(0, DEFAULT_PALETTE.layers.length);
+  while (layers.length < DEFAULT_PALETTE.layers.length) {
+    layers.push(DEFAULT_PALETTE.layers[layers.length]);
   }
   return {
-    bg: palette.bg || FALLBACK_PALETTE.bg,
-    ink: palette.ink || FALLBACK_PALETTE.ink,
+    bg: palette.bg || DEFAULT_PALETTE.bg,
+    ink: palette.ink || DEFAULT_PALETTE.ink,
     layers
   };
 }
 
-function ensureNumerology(NUM) {
+function normaliseNumerology(NUM) {
   if (!NUM) {
-    return FALLBACK_NUM;
+    return DEFAULT_NUM;
   }
   const merged = {};
-  for (const key of Object.keys(FALLBACK_NUM)) {
-    merged[key] = Number.isFinite(NUM[key]) ? NUM[key] : FALLBACK_NUM[key];
+  for (const key of Object.keys(DEFAULT_NUM)) {
+    merged[key] = Number.isFinite(NUM[key]) ? NUM[key] : DEFAULT_NUM[key];
   }
   return merged;
 }
 
-function prepareCanvas(ctx, width, height, background) {
-  ctx.canvas.width = width;
-  ctx.canvas.height = height;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.fillStyle = background;
+function configureContext(ctx) {
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+}
+
+function fillBackground(ctx, width, height, color) {
+  ctx.fillStyle = color;
   ctx.fillRect(0, 0, width, height);
 }
 
 function drawVesicaField(ctx, { width, height, color, NUM }) {
   const centerX = width / 2;
   const centerY = height / 2;
-  const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE * (NUM.NINE / NUM.THREE);
+  const radius = Math.min(width, height) / NUM.THIRTYTHREE * (NUM.NINE / NUM.THREE);
 
   ctx.save();
   ctx.strokeStyle = color;
   ctx.globalAlpha = 0.32;
-  ctx.lineWidth = Math.max(1.25, baseRadius / NUM.NINETYNINE * NUM.SEVEN);
+  ctx.lineWidth = Math.max(1.25, radius / NUM.NINETYNINE * NUM.SEVEN);
 
   const offsets = [
-    { x: -baseRadius / NUM.THREE, y: 0 },
-    { x: baseRadius / NUM.THREE, y: 0 },
-    { x: 0, y: -baseRadius / NUM.THREE },
-    { x: 0, y: baseRadius / NUM.THREE }
+    { x: -radius / NUM.THREE, y: 0 },
+    { x: radius / NUM.THREE, y: 0 },
+    { x: 0, y: -radius / NUM.THREE },
+    { x: 0, y: radius / NUM.THREE }
   ];
-  for (let i = 0; i < offsets.length; i += 1) {
-    const offset = offsets[i];
-    drawCircleOutline(ctx, centerX + offset.x, centerY + offset.y, baseRadius);
-  }
+  offsets.forEach((offset) => {
+    drawCircleOutline(ctx, centerX + offset.x, centerY + offset.y, radius);
+  });
 
-  // Harmonic rings reinforce depth without animation.
   const ringCount = NUM.SEVEN;
   for (let i = 1; i <= ringCount; i += 1) {
-    const ringRadius = baseRadius * (1 + i / (ringCount + NUM.THREE));
+    const ringRadius = radius * (1 + i / (ringCount + NUM.THREE));
+    ctx.globalAlpha = 0.18;
     drawCircleOutline(ctx, centerX, centerY, ringRadius);
   }
 
-  // Vesica grid: lines anchored to 3x3 intersections.
-  const gridExtent = baseRadius * (NUM.ELEVEN / NUM.NINE);
+  ctx.globalAlpha = 0.14;
+  const gridExtent = radius * (NUM.ELEVEN / NUM.NINE);
   const steps = NUM.NINE;
-  ctx.globalAlpha = 0.18;
   for (let i = -steps; i <= steps; i += 1) {
     const offset = (i / steps) * gridExtent;
-    ctx.beginPath();
-    ctx.moveTo(centerX + offset, centerY - gridExtent);
-    ctx.lineTo(centerX + offset, centerY + gridExtent);
-    ctx.stroke();
-
-    ctx.beginPath();
-    ctx.moveTo(centerX - gridExtent, centerY + offset);
-    ctx.lineTo(centerX + gridExtent, centerY + offset);
-
-  Layer order (outer to inner) is intentional:
-    1) Vesica field provides the calm backdrop.
-    2) Tree-of-Life scaffold anchors nodes and paths.
-    3) Fibonacci curve adds gentle spiral motion without animation.
-    4) Double helix lattice offers depth using static strands.
-
-  All helpers are small pure functions so future edits remain additive.
-*/
-
-const FALLBACK_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-});
-
-export function renderHelix(ctx, options) {
-  if (!ctx) {
-    return;
-  }
-
-  const opts = options || {};
-  const width = Math.max(1, opts.width || ctx.canvas.width);
-  const height = Math.max(1, opts.height || ctx.canvas.height);
-  const palette = normalizePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-  ctx.save();
-  ctx.canvas.width = width;
-  ctx.canvas.height = height;
-
-  // Calm background wash: drawn once to avoid flicker or motion.
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  paintVesicaField(ctx, { width, height, palette, NUM });
-  paintTreeOfLife(ctx, { width, height, palette, NUM });
-  paintFibonacciCurve(ctx, { width, height, palette, NUM });
-  paintHelixLattice(ctx, { width, height, palette, NUM });
-
-  ctx.restore();
-}
-
-function normalizePalette(palette) {
-  if (!palette || !Array.isArray(palette.layers)) {
-    return FALLBACK_PALETTE;
-  }
-  const layers = palette.layers.slice(0, FALLBACK_PALETTE.layers.length);
-  while (layers.length < FALLBACK_PALETTE.layers.length) {
-    layers.push(FALLBACK_PALETTE.layers[layers.length]);
-  }
-  return {
-    bg: palette.bg || FALLBACK_PALETTE.bg,
-    ink: palette.ink || FALLBACK_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(NUM) {
-  if (NUM) {
-    return NUM;
-  }
-  return Object.freeze({
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  });
-}
-
-function paintVesicaField(ctx, { width, height, palette, NUM }) {
-  const radius = Math.min(width, height) / NUM.THIRTYTHREE * NUM.NINE;
-  const cx = width / 2;
-  const cy = height / 2;
-  const offset = radius * (NUM.SEVEN / NUM.TWENTYTWO);
-
-  ctx.save();
-  ctx.globalAlpha = 0.24;
-  ctx.fillStyle = palette.layers[0];
-  drawCircle(ctx, cx - offset, cy, radius, { fill: true });
-  ctx.fillStyle = palette.layers[1];
-  drawCircle(ctx, cx + offset, cy, radius, { fill: true });
-
-  // Harmonic rings maintain layered depth without motion.
-  const rings = [1, NUM.THIRTYTHREE / NUM.TWENTYTWO, NUM.NINETYNINE / NUM.ONEFORTYFOUR];
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, Math.min(width, height) / NUM.ONEFORTYFOUR);
-  rings.forEach((scale, idx) => {
-    ctx.globalAlpha = 0.12 + idx * 0.06;
-    drawCircle(ctx, cx, cy, radius * scale, { stroke: true });
-  });
-
-  // Vesica grid uses 3x3 symmetry; spacing keyed to numerology constants.
-  ctx.globalAlpha = 0.18;
-  const gridCount = NUM.THREE;
-  const spacing = radius / (gridCount + 1);
-  for (let gx = -gridCount; gx <= gridCount; gx += 1) {
-    const x = cx + gx * spacing * (NUM.SEVEN / NUM.NINE);
-    ctx.beginPath();
-    ctx.moveTo(x, cy - radius);
-    ctx.lineTo(x, cy + radius);
-    ctx.stroke();
-  }
-  for (let gy = -gridCount; gy <= gridCount; gy += 1) {
-    const y = cy + gy * spacing * (NUM.SEVEN / NUM.NINE);
-    ctx.beginPath();
-    ctx.moveTo(cx - radius, y);
-    ctx.lineTo(cx + radius, y);
-    ctx.stroke();
+    drawLine(ctx, centerX + offset, centerY - gridExtent, centerX + offset, centerY + gridExtent);
+    drawLine(ctx, centerX - gridExtent, centerY + offset, centerX + gridExtent, centerY + offset);
   }
 
   ctx.restore();
 }
 
-function drawTreeOfLife(ctx, { width, height, lineColor, nodeColor, NUM }) {
-  const topMargin = height / NUM.TWENTYTWO * NUM.THREE;
-  const verticalSpan = height - topMargin * 2;
-  const verticalStep = verticalSpan / NUM.SEVEN;
-  const lateralSpread = width / NUM.THREE;
-  const centerX = width / 2;
-
-  const nodes = [
-    { id: "keter", x: centerX, y: topMargin },
-    { id: "chokmah", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep },
-    { id: "binah", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep },
-    { id: "chesed", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
-    { id: "gevurah", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
-    { id: "tiferet", x: centerX, y: topMargin + verticalStep * 3 },
-    { id: "netzach", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
-    { id: "hod", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
-    { id: "yesod", x: centerX, y: topMargin + verticalStep * 5 },
-    { id: "malkuth", x: centerX, y: topMargin + verticalStep * 6 }
-  ];
-
-  const nodeMap = new Map();
-  for (let i = 0; i < nodes.length; i += 1) {
-    nodeMap.set(nodes[i].id, nodes[i]);
-  }
-
-  const paths = [
-    ["keter", "chokmah"],
-    ["keter", "binah"],
-    ["keter", "tiferet"],
-    ["chokmah", "binah"],
-    ["chokmah", "chesed"],
-    ["chokmah", "tiferet"],
-    ["binah", "gevurah"],
-    ["binah", "tiferet"],
-    ["chesed", "gevurah"],
-    ["chesed", "tiferet"],
-    ["chesed", "netzach"],
-    ["gevurah", "tiferet"],
-    ["gevurah", "hod"],
-    ["tiferet", "netzach"],
-    ["tiferet", "hod"],
-    ["tiferet", "yesod"],
-    ["netzach", "hod"],
-    ["netzach", "yesod"],
-    ["hod", "yesod"],
-    ["netzach", "malkuth"],
-    ["hod", "malkuth"],
-    ["yesod", "malkuth"]
-  ];
+function drawTreeOfLife(ctx, { width, height, strokeColor, nodeColor, haloColor, NUM }) {
+  const nodes = computeTreeNodes(width, height, NUM);
+  const paths = computeTreePaths();
+  const strokeWidth = Math.max(1.2, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE));
+  const nodeRadius = Math.max(6, Math.min(width, height) / NUM.NINETYNINE * (NUM.THREE / NUM.SEVEN));
 
   ctx.save();
   ctx.globalAlpha = 0.6;
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = Math.max(1.2, width / (NUM.ONEFORTYFOUR * 1.2));
-  for (let i = 0; i < paths.length; i += 1) {
-    const [startId, endId] = paths[i];
-    const start = nodeMap.get(startId);
-    const end = nodeMap.get(endId);
-    if (!start || !end) {
-      continue;
-function paintTreeOfLife(ctx, { width, height, palette, NUM }) {
-  const nodes = getTreeNodes({ width, height, NUM });
-  const paths = getTreePaths();
-  const strokeScaled = Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE);
-  const strokeWidth = Math.max(NUM.THIRTYTHREE / NUM.TWENTYTWO, strokeScaled);
-  const radiusScaled = Math.min(width, height) / (NUM.NINETYNINE / NUM.THREE);
-  const nodeRadius = Math.max(NUM.THREE * (NUM.TWENTYTWO / NUM.ELEVEN), radiusScaled);
-
-  ctx.save();
-  ctx.globalAlpha = 0.68;
-  ctx.strokeStyle = palette.layers[2];
+  ctx.strokeStyle = strokeColor;
   ctx.lineWidth = strokeWidth;
   paths.forEach(([from, to]) => {
     const start = nodes[from];
@@ -336,37 +166,18 @@ function paintTreeOfLife(ctx, { width, height, palette, NUM }) {
     if (!start || !end) {
       return;
     }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
-  }
-
-  ctx.globalAlpha = 0.88;
-  const nodeRadius = Math.max(6, width / NUM.NINETYNINE);
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = Math.max(1, nodeRadius / NUM.THIRTYTHREE * NUM.THREE);
-  for (let i = 0; i < nodes.length; i += 1) {
-    const node = nodes[i];
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-  }
+    drawLine(ctx, start.x, start.y, end.x, end.y);
   });
 
-  // Nodes rendered last for clarity; gentle halos avoid harsh focus.
   ctx.globalAlpha = 0.92;
-  ctx.fillStyle = palette.ink;
-  nodes.forEach((node) => {
+  ctx.fillStyle = nodeColor;
+  ctx.strokeStyle = haloColor;
+  ctx.lineWidth = strokeWidth / NUM.THREE;
+  Object.values(nodes).forEach((node) => {
     drawCircle(ctx, node.x, node.y, nodeRadius, { fill: true });
     ctx.globalAlpha = 0.55;
-    ctx.strokeStyle = palette.layers[5];
-    ctx.lineWidth = strokeWidth / NUM.THREE;
     drawCircle(ctx, node.x, node.y, nodeRadius * (NUM.THIRTYTHREE / NUM.TWENTYTWO), { stroke: true });
     ctx.globalAlpha = 0.92;
-    ctx.strokeStyle = palette.layers[2];
   });
 
   ctx.restore();
@@ -378,20 +189,20 @@ function drawFibonacciCurve(ctx, { width, height, color, NUM }) {
   const maxRadius = Math.min(width, height) / NUM.THREE;
   const phi = (1 + Math.sqrt(5)) / 2;
   const steps = NUM.TWENTYTWO;
-  const rotations = NUM.ELEVEN / NUM.THREE; // 3.66 turns keeps the spiral calm.
-  const growthSteps = NUM.SEVEN;
-  const startRadius = maxRadius / Math.pow(phi, growthSteps);
+  const rotations = NUM.ELEVEN / NUM.THREE; // 3.66 turns keeps motion implied yet static.
+  const growth = NUM.SEVEN;
+  const startRadius = maxRadius / Math.pow(phi, growth);
 
   ctx.save();
   ctx.strokeStyle = color;
-  ctx.globalAlpha = 0.72;
+  ctx.globalAlpha = 0.7;
   ctx.lineWidth = Math.max(1.4, maxRadius / NUM.ONEFORTYFOUR * NUM.THREE);
   ctx.beginPath();
 
   for (let i = 0; i <= steps; i += 1) {
     const t = i / steps;
     const angle = rotations * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, growthSteps * t);
+    const radius = startRadius * Math.pow(phi, growth * t);
     const x = centerX + Math.cos(angle) * radius;
     const y = centerY + Math.sin(angle) * radius;
     if (i === 0) {
@@ -402,165 +213,46 @@ function drawFibonacciCurve(ctx, { width, height, color, NUM }) {
   }
 
   ctx.stroke();
-
-  // Anchor points along the spiral provide gentle focus points.
-  const markerCount = NUM.NINE;
-  ctx.fillStyle = color;
-  ctx.globalAlpha = 0.5;
-  const markerRadius = Math.max(3, maxRadius / NUM.ONEFORTYFOUR * NUM.THREE);
-  for (let i = 1; i <= markerCount; i += 1) {
-    const t = i / (markerCount + 1);
-    const angle = rotations * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, growthSteps * t);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-    ctx.beginPath();
-    ctx.arc(x, y, markerRadius, 0, Math.PI * 2);
-    ctx.fill();
-  }
-
   ctx.restore();
 }
 
-function drawHelixLattice(ctx, { width, height, strandA, strandB, rungColor, NUM }) {
-  const topMargin = height / NUM.ELEVEN;
-  const helixHeight = height - topMargin * 2;
+function drawHelixLattice(ctx, { width, height, strandAColor, strandBColor, rungColor, NUM }) {
+  const sampleCount = NUM.ONEFORTYFOUR;
+  const marginY = height / NUM.ELEVEN;
+  const spanY = height - marginY * 2;
   const centerX = width / 2;
-  const amplitude = width / NUM.NINE;
-  const steps = NUM.ONEFORTYFOUR;
-  const turns = NUM.THREE; // three full twists for symbolic balance.
-function getTreeNodes({ width, height, NUM }) {
-  const marginX = width / NUM.NINETYNINE * NUM.ELEVEN;
-  const marginY = height / NUM.NINETYNINE * NUM.ELEVEN;
-  const usableWidth = width - marginX * 2;
-  const usableHeight = height - marginY * 2;
-  const layout = [
-    { u: 0.5, v: 0.04 },
-    { u: 0.75, v: 0.18 },
-    { u: 0.25, v: 0.18 },
-    { u: 0.75, v: 0.32 },
-    { u: 0.25, v: 0.32 },
-    { u: 0.5, v: 0.48 },
-    { u: 0.82, v: 0.64 },
-    { u: 0.18, v: 0.64 },
-    { u: 0.5, v: 0.78 },
-    { u: 0.5, v: 0.92 }
-  ];
-  return layout.map((pos) => ({
-    x: marginX + pos.u * usableWidth,
-    y: marginY + pos.v * usableHeight
-  }));
-}
+  const amplitude = Math.min(width / NUM.THREE, width / NUM.SEVEN);
+  const phaseShift = Math.PI / NUM.THREE;
 
-function getTreePaths() {
-  return [
-    [0, 1], [0, 2], [0, 5],
-    [1, 2], [1, 3], [1, 5],
-    [2, 4], [2, 5],
-    [3, 4], [3, 5], [3, 6],
-    [4, 5], [4, 7],
-    [5, 6], [5, 7], [5, 8],
-    [6, 8], [6, 9],
-    [7, 8], [7, 9],
-    [8, 9]
-  ];
-}
-
-function paintFibonacciCurve(ctx, { width, height, palette, NUM }) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO;
-  const totalTurns = NUM.NINE / NUM.THREE;
-  const totalTheta = totalTurns * Math.PI * 2;
-  const growth = Math.log(phi) / (Math.PI / 2);
-  const baseRadius = Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THIRTYTHREE;
-  const centerX = width * 0.3;
-  const centerY = height * 0.6;
-  const points = [];
-
-  const pointsA = [];
-  const pointsB = [];
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const angle = turns * Math.PI * 2 * t;
-    const y = topMargin + helixHeight * t;
-    const xA = centerX + Math.sin(angle) * amplitude;
-    const xB = centerX + Math.sin(angle + Math.PI) * amplitude;
-    pointsA.push({ x: xA, y });
-    pointsB.push({ x: xB, y });
-  }
-
-  ctx.save();
-  ctx.globalAlpha = 0.66;
-  ctx.lineWidth = Math.max(1.4, width / NUM.ONEFORTYFOUR * NUM.THREE);
-  drawPolyline(ctx, pointsA, strandA);
-  drawPolyline(ctx, pointsB, strandB);
-
-  // Cross rungs referencing 33 + 66 ratios for stable lattice.
-  const rungInterval = Math.max(2, Math.floor(steps / NUM.THIRTYTHREE));
-  ctx.strokeStyle = rungColor;
-  ctx.globalAlpha = 0.4;
-  ctx.lineWidth = Math.max(1, width / NUM.ONEFORTYFOUR * NUM.SEVEN / NUM.ELEVEN);
-  for (let i = 0; i <= steps; i += rungInterval) {
-    const a = pointsA[i];
-    const b = pointsB[i];
-    const theta = totalTheta * t;
-    const radius = baseRadius * Math.exp(growth * theta);
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    points.push({ x, y });
-  }
-
-  const strokeScaled = Math.min(width, height) / (NUM.ONEFORTYFOUR / (NUM.TWENTYTWO / NUM.ELEVEN));
-  const strokeWidth = Math.max(NUM.TWENTYTWO / NUM.ELEVEN, strokeScaled);
-
-  ctx.save();
-  ctx.globalAlpha = 0.9;
-  ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = strokeWidth;
-  tracePolyline(ctx, points);
-  ctx.restore();
-}
-
-function paintHelixLattice(ctx, { width, height, palette, NUM }) {
-  const strandSamples = NUM.ONEFORTYFOUR;
-  const frequency = NUM.THREE;
-  const amplitude = height / NUM.THIRTYTHREE * NUM.SEVEN;
-  const midY = height / 2;
   const strandA = [];
   const strandB = [];
-
-  for (let i = 0; i <= strandSamples; i += 1) {
-    const t = i / strandSamples;
-    const theta = t * Math.PI * 2 * frequency;
-    const x = t * width;
-    strandA.push({ x, y: midY + Math.sin(theta) * amplitude });
-    strandB.push({ x, y: midY + Math.sin(theta + Math.PI) * amplitude });
+  for (let i = 0; i < sampleCount; i += 1) {
+    const t = i / (sampleCount - 1);
+    const angle = t * Math.PI * NUM.THIRTYTHREE / NUM.ELEVEN;
+    const y = marginY + spanY * t;
+    strandA.push({ x: centerX + Math.sin(angle) * amplitude, y });
+    strandB.push({ x: centerX - Math.sin(angle + phaseShift) * amplitude, y });
   }
 
-  const baseLine = Math.min(width, height) / NUM.ONEFORTYFOUR;
-  const lineWidth = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, baseLine);
-
   ctx.save();
-  ctx.globalAlpha = 0.78;
-  ctx.lineWidth = lineWidth;
-  ctx.strokeStyle = palette.layers[4];
-  tracePolyline(ctx, strandA);
-  ctx.strokeStyle = palette.layers[5];
-  tracePolyline(ctx, strandB);
+  ctx.lineWidth = Math.max(1.2, width / NUM.ONEFORTYFOUR);
 
+  ctx.strokeStyle = strandAColor;
+  drawPolyline(ctx, strandA);
+
+  ctx.strokeStyle = strandBColor;
+  drawPolyline(ctx, strandB);
+
+  ctx.strokeStyle = rungColor;
   ctx.globalAlpha = 0.4;
-  ctx.strokeStyle = palette.layers[2];
-  const rungStep = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, Math.floor(strandSamples / NUM.TWENTYTWO));
-  for (let i = 0; i <= strandSamples; i += rungStep) {
+  const rungStep = Math.max(1, Math.floor(sampleCount / NUM.TWENTYTWO));
+  for (let i = 0; i < sampleCount; i += rungStep) {
     const a = strandA[i];
     const b = strandB[i];
     if (!a || !b) {
       continue;
     }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
+    drawLine(ctx, a.x, a.y, b.x, b.y);
   }
 
   ctx.restore();
@@ -572,29 +264,80 @@ function drawCircleOutline(ctx, x, y, radius) {
   ctx.stroke();
 }
 
-function drawPolyline(ctx, points, strokeStyle) {
-function drawCircle(ctx, cx, cy, radius, options = {}) {
+function drawCircle(ctx, x, y, radius, mode) {
   ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  if (options.fill) {
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  if (mode && mode.fill) {
     ctx.fill();
   }
-  if (options.stroke || !options.fill) {
+  if (mode && mode.stroke) {
     ctx.stroke();
   }
 }
 
-function tracePolyline(ctx, points) {
-  if (!points.length) {
+function drawLine(ctx, x1, y1, x2, y2) {
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+}
+
+function drawPolyline(ctx, points) {
+  if (!Array.isArray(points) || points.length === 0) {
     return;
   }
-  ctx.strokeStyle = strokeStyle;
   ctx.beginPath();
   ctx.moveTo(points[0].x, points[0].y);
   for (let i = 1; i < points.length; i += 1) {
-    const point = points[i];
-    ctx.lineTo(point.x, point.y);
+    ctx.lineTo(points[i].x, points[i].y);
   }
   ctx.stroke();
 }
 
+function computeTreeNodes(width, height, NUM) {
+  const topMargin = height / NUM.TWENTYTWO * NUM.THREE;
+  const verticalSpan = height - topMargin * 2;
+  const verticalStep = verticalSpan / NUM.SEVEN;
+  const lateralSpread = width / NUM.THREE;
+  const centerX = width / 2;
+
+  return {
+    keter: { x: centerX, y: topMargin },
+    chokmah: { x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep },
+    binah: { x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep },
+    chesed: { x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
+    gevurah: { x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
+    tiferet: { x: centerX, y: topMargin + verticalStep * 3 },
+    netzach: { x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
+    hod: { x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
+    yesod: { x: centerX, y: topMargin + verticalStep * 5 },
+    malkuth: { x: centerX, y: topMargin + verticalStep * 6 }
+  };
+}
+
+function computeTreePaths() {
+  return [
+    ['keter', 'chokmah'],
+    ['keter', 'binah'],
+    ['keter', 'tiferet'],
+    ['chokmah', 'binah'],
+    ['chokmah', 'chesed'],
+    ['chokmah', 'tiferet'],
+    ['binah', 'gevurah'],
+    ['binah', 'tiferet'],
+    ['chesed', 'gevurah'],
+    ['chesed', 'tiferet'],
+    ['chesed', 'netzach'],
+    ['gevurah', 'tiferet'],
+    ['gevurah', 'hod'],
+    ['tiferet', 'netzach'],
+    ['tiferet', 'hod'],
+    ['tiferet', 'yesod'],
+    ['netzach', 'hod'],
+    ['netzach', 'yesod'],
+    ['hod', 'yesod'],
+    ['netzach', 'malkuth'],
+    ['hod', 'malkuth'],
+    ['yesod', 'malkuth']
+  ];
+}


### PR DESCRIPTION
## Summary
- clean up the offline index shell so the palette loader and status messages match the ND-safe brief
- rebuild the helix renderer module with small pure helpers covering the vesica field, tree-of-life, fibonacci spiral, and double-helix lattice layers
- ensure numerology constants and palette fallbacks are normalised for deterministic, offline-only rendering

## Testing
- node -e "import('./js/helix-renderer.mjs').then(() => console.log('module ok')).catch(err => { console.error(err); process.exit(1); });"

------
https://chatgpt.com/codex/tasks/task_e_68d25da5cc448328a54610984808c784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Runtime color palette loading with graceful fallback for improved reliability.
  - Clear status updates shown during rendering.

- Refactor
  - Switched to a single static render (no animation) for a calmer, faster load experience.
  - Streamlined page structure for quicker startup.

- Style
  - Simplified styling with updated font, padding, and palette variables for a cleaner look.

- Chores
  - Reduced inline scripts and legacy markup to modernize the page and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->