### PR TITLE
Refine offline helix renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,51 +7,18 @@
   <meta name="color-scheme" content="light dark">
   <style>
     /* ND-safe presentation: calm contrast, generous spacing, zero motion */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9da0c5; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:16px 18px; border-bottom:1px solid #1d1d2a; }
-    header strong { letter-spacing:0.04em; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:20px auto; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 24px; color:var(--muted); padding:0 16px; text-align:center; }
-  <meta name="color-scheme" content="dark light">
-  <style>
-    /* ND-safe presentation: calm palette, high readability, no motion */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
     html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    h1 { margin:0; font-size:20px; letter-spacing:0.02em; }
+    header { padding:16px 18px; border-bottom:1px solid #1d1d2a; }
+    h1 { margin:0; font-size:20px; letter-spacing:0.03em; text-transform:uppercase; }
     .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:18px auto; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 20px; color:var(--muted); padding:0 16px; text-align:center; }
+    #stage { display:block; margin:18px auto 12px; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
+    .note { max-width:900px; margin:0 auto 24px; color:var(--muted); padding:0 16px; text-align:center; }
     code { background:#11111a; padding:2px 4px; border-radius:3px; }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Preparing canvas…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static study of Vesica, Tree-of-Life, Fibonacci spiral, and double helix lattice. Open this file directly; no animation or external dependencies.</p>
-
-  <script type="module">
-    import { renderHelix } from "./js/helix-renderer.mjs";
-
-    const status = document.getElementById("status");
-    const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
-
-    if (!ctx) {
-      status.textContent = "Canvas unavailable; rendering skipped.";
-      throw new Error("Canvas context missing");
-    }
-
-    /**
-     * Attempt to load palette overrides from disk. The fetch call only touches
-     * the local file path; failures fall back to the baked-in palette so the
-     * render still completes offline.
     <h1>Cosmic Helix Renderer</h1>
     <div class="status" id="status">Preparing palette…</div>
   </header>
@@ -62,27 +29,16 @@
   <script type="module">
     import { renderHelix } from './js/helix-renderer.mjs';
 
-    const status = document.getElementById('status');
+    const statusEl = document.getElementById('status');
     const canvas = document.getElementById('stage');
     const ctx = canvas.getContext('2d');
 
-    /**
-     * Attempt to read palette data from disk. The fetch call only touches the local file system,
-     * never the network; failures fall back to the baked-in palette so rendering stays ND-safe.
-     */
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error("Palette not accessible");
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
+    const fallbackPalette = {
+      bg: '#0b0b12',
+      ink: '#e8e8f0',
+      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
+    };
 
-    /** Numerology constants shared across all layers. */
     const NUM = Object.freeze({
       THREE: 3,
       SEVEN: 7,
@@ -94,32 +50,32 @@
       ONEFORTYFOUR: 144
     });
 
-    const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-    };
+    function setStatus(message) {
+      statusEl.textContent = message;
+    }
 
-    const paletteData = await loadPalette("./data/palette.json");
-    const palette = paletteData || fallbackPalette;
-    status.textContent = paletteData
-      ? "Palette loaded from data/palette.json."
-      : "Palette missing or blocked; using ND-safe fallback.";
+    async function loadPalette(path) {
+      try {
+        const response = await fetch(path, { cache: 'no-store' });
+        if (!response.ok) {
+          throw new Error('Palette not accessible');
+        }
+        return await response.json();
+      } catch (error) {
+        return null;
+      }
+    }
 
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette,
-      NUM
-    });
-    status.textContent = paletteData ? 'Palette loaded. Rendering static layers…' : 'Palette missing or blocked; using safe fallback.';
+    const paletteData = await loadPalette('./data/palette.json');
+    const activePalette = paletteData || fallbackPalette;
+    setStatus(paletteData ? 'Palette loaded. Rendering static layers…' : 'Palette missing or blocked; using ND-safe fallback.');
 
     if (!ctx) {
-      status.textContent = 'Canvas context unavailable in this browser.';
+      setStatus('Canvas context unavailable; ND-safe fallback triggered.');
     } else {
-      // Single render call: no animation loop keeps the scene calm and sensory-safe.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      status.textContent = 'Rendered without motion.';
+      // Single render call keeps the canvas motionless and sensory-safe.
+      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });
+      setStatus('Rendered calm layered geometry without motion.');
     }
   </script>
 </body>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -5,17 +5,16 @@
   Layer order is intentional to preserve calm depth:
     1. Vesica field (grounding lattice of intersecting circles)
     2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci spiral (phi-based curve for gentle motion cues without animation)
-    4. Double-helix lattice (mirrored strands with 144 sample points)
+    3. Fibonacci spiral (phi-guided curve rendered without motion)
+    4. Double helix lattice (mirrored strands sampled at 144 points)
 
-  All helpers are pure and only depend on the arguments passed in.
-  This keeps edits deterministic and prevents accidental motion loops.
+  All helpers are pure: no shared mutable state, no timers, no animation.
 */
 
 const FALLBACK_PALETTE = Object.freeze({
-  bg: "#0b0b12",
-  ink: "#e8e8f0",
-  layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
+  bg: '#0b0b12',
+  ink: '#e8e8f0',
+  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
 });
 
 const FALLBACK_NUM = Object.freeze({
@@ -34,33 +33,30 @@ export function renderHelix(ctx, options = {}) {
     return;
   }
 
-  const width = Number.isFinite(options.width) ? options.width : 1440;
-  const height = Number.isFinite(options.height) ? options.height : 900;
+  const width = sanitiseDimension(options.width, ctx.canvas.width || 1440);
+  const height = sanitiseDimension(options.height, ctx.canvas.height || 900);
   const palette = normalisePalette(options.palette);
-  const NUM = ensureNumerology(options.NUM);
+  const NUM = normaliseNumerology(options.NUM);
 
   ctx.save();
-  prepareCanvas(ctx, width, height, palette.bg);
+  resetCanvas(ctx, width, height, palette.bg);
 
-  drawVesicaField(ctx, { width, height, color: palette.layers[0], NUM });
-  drawTreeOfLife(ctx, {
-    width,
-    height,
-    lineColor: palette.layers[1],
-    nodeColor: palette.ink,
-    NUM
-  });
-  drawFibonacciCurve(ctx, { width, height, color: palette.layers[2], NUM });
-  drawHelixLattice(ctx, {
-    width,
-    height,
-    strandA: palette.layers[3],
-    strandB: palette.layers[4],
-    rungColor: palette.layers[5],
-    NUM
-  });
+  paintVesicaField(ctx, { width, height, palette, NUM });
+  paintTreeOfLife(ctx, { width, height, palette, NUM });
+  paintFibonacciCurve(ctx, { width, height, palette, NUM });
+  paintHelixLattice(ctx, { width, height, palette, NUM });
 
   ctx.restore();
+}
+
+function sanitiseDimension(value, fallback) {
+  if (Number.isFinite(value) && value > 0) {
+    return value;
+  }
+  if (Number.isFinite(fallback) && fallback > 0) {
+    return fallback;
+  }
+  return 1;
 }
 
 function normalisePalette(palette) {
@@ -78,7 +74,7 @@ function normalisePalette(palette) {
   };
 }
 
-function ensureNumerology(NUM) {
+function normaliseNumerology(NUM) {
   if (!NUM) {
     return FALLBACK_NUM;
   }
@@ -89,347 +85,84 @@ function ensureNumerology(NUM) {
   return merged;
 }
 
-function prepareCanvas(ctx, width, height, background) {
+function resetCanvas(ctx, width, height, background) {
   ctx.canvas.width = width;
   ctx.canvas.height = height;
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
   ctx.fillStyle = background;
   ctx.fillRect(0, 0, width, height);
 }
 
-function drawVesicaField(ctx, { width, height, color, NUM }) {
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE * (NUM.NINE / NUM.THREE);
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.globalAlpha = 0.32;
-  ctx.lineWidth = Math.max(1.25, baseRadius / NUM.NINETYNINE * NUM.SEVEN);
-
-  const offsets = [
-    { x: -baseRadius / NUM.THREE, y: 0 },
-    { x: baseRadius / NUM.THREE, y: 0 },
-    { x: 0, y: -baseRadius / NUM.THREE },
-    { x: 0, y: baseRadius / NUM.THREE }
-  ];
-  for (let i = 0; i < offsets.length; i += 1) {
-    const offset = offsets[i];
-    drawCircleOutline(ctx, centerX + offset.x, centerY + offset.y, baseRadius);
-  }
-
-  // Harmonic rings reinforce depth without animation.
-  const ringCount = NUM.SEVEN;
-  for (let i = 1; i <= ringCount; i += 1) {
-    const ringRadius = baseRadius * (1 + i / (ringCount + NUM.THREE));
-    drawCircleOutline(ctx, centerX, centerY, ringRadius);
-  }
-
-  // Vesica grid: lines anchored to 3x3 intersections.
-  const gridExtent = baseRadius * (NUM.ELEVEN / NUM.NINE);
-  const steps = NUM.NINE;
-  ctx.globalAlpha = 0.18;
-  for (let i = -steps; i <= steps; i += 1) {
-    const offset = (i / steps) * gridExtent;
-    ctx.beginPath();
-    ctx.moveTo(centerX + offset, centerY - gridExtent);
-    ctx.lineTo(centerX + offset, centerY + gridExtent);
-    ctx.stroke();
-
-    ctx.beginPath();
-    ctx.moveTo(centerX - gridExtent, centerY + offset);
-    ctx.lineTo(centerX + gridExtent, centerY + offset);
-
-  Layer order (outer to inner) is intentional:
-    1) Vesica field provides the calm backdrop.
-    2) Tree-of-Life scaffold anchors nodes and paths.
-    3) Fibonacci curve adds gentle spiral motion without animation.
-    4) Double helix lattice offers depth using static strands.
-
-  All helpers are small pure functions so future edits remain additive.
-*/
-
-const FALLBACK_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-});
-
-export function renderHelix(ctx, options) {
-  if (!ctx) {
-    return;
-  }
-
-  const opts = options || {};
-  const width = Math.max(1, opts.width || ctx.canvas.width);
-  const height = Math.max(1, opts.height || ctx.canvas.height);
-  const palette = normalizePalette(opts.palette);
-  const NUM = ensureNumerology(opts.NUM);
-
-  ctx.save();
-  ctx.canvas.width = width;
-  ctx.canvas.height = height;
-
-  // Calm background wash: drawn once to avoid flicker or motion.
-  ctx.fillStyle = palette.bg;
-  ctx.fillRect(0, 0, width, height);
-
-  paintVesicaField(ctx, { width, height, palette, NUM });
-  paintTreeOfLife(ctx, { width, height, palette, NUM });
-  paintFibonacciCurve(ctx, { width, height, palette, NUM });
-  paintHelixLattice(ctx, { width, height, palette, NUM });
-
-  ctx.restore();
-}
-
-function normalizePalette(palette) {
-  if (!palette || !Array.isArray(palette.layers)) {
-    return FALLBACK_PALETTE;
-  }
-  const layers = palette.layers.slice(0, FALLBACK_PALETTE.layers.length);
-  while (layers.length < FALLBACK_PALETTE.layers.length) {
-    layers.push(FALLBACK_PALETTE.layers[layers.length]);
-  }
-  return {
-    bg: palette.bg || FALLBACK_PALETTE.bg,
-    ink: palette.ink || FALLBACK_PALETTE.ink,
-    layers
-  };
-}
-
-function ensureNumerology(NUM) {
-  if (NUM) {
-    return NUM;
-  }
-  return Object.freeze({
-    THREE: 3,
-    SEVEN: 7,
-    NINE: 9,
-    ELEVEN: 11,
-    TWENTYTWO: 22,
-    THIRTYTHREE: 33,
-    NINETYNINE: 99,
-    ONEFORTYFOUR: 144
-  });
-}
-
 function paintVesicaField(ctx, { width, height, palette, NUM }) {
   const radius = Math.min(width, height) / NUM.THIRTYTHREE * NUM.NINE;
-  const cx = width / 2;
-  const cy = height / 2;
+  const centerX = width / 2;
+  const centerY = height / 2;
   const offset = radius * (NUM.SEVEN / NUM.TWENTYTWO);
 
   ctx.save();
-  ctx.globalAlpha = 0.24;
+  ctx.globalAlpha = 0.26;
   ctx.fillStyle = palette.layers[0];
-  drawCircle(ctx, cx - offset, cy, radius, { fill: true });
+  drawCircle(ctx, centerX - offset, centerY, radius, { fill: true });
   ctx.fillStyle = palette.layers[1];
-  drawCircle(ctx, cx + offset, cy, radius, { fill: true });
+  drawCircle(ctx, centerX + offset, centerY, radius, { fill: true });
 
-  // Harmonic rings maintain layered depth without motion.
-  const rings = [1, NUM.THIRTYTHREE / NUM.TWENTYTWO, NUM.NINETYNINE / NUM.ONEFORTYFOUR];
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, Math.min(width, height) / NUM.ONEFORTYFOUR);
-  rings.forEach((scale, idx) => {
-    ctx.globalAlpha = 0.12 + idx * 0.06;
-    drawCircle(ctx, cx, cy, radius * scale, { stroke: true });
-  });
-
-  // Vesica grid uses 3x3 symmetry; spacing keyed to numerology constants.
+  // Rings use numerology ratios to hold depth without motion.
+  const ringCount = NUM.SEVEN;
   ctx.globalAlpha = 0.18;
-  const gridCount = NUM.THREE;
-  const spacing = radius / (gridCount + 1);
-  for (let gx = -gridCount; gx <= gridCount; gx += 1) {
-    const x = cx + gx * spacing * (NUM.SEVEN / NUM.NINE);
-    ctx.beginPath();
-    ctx.moveTo(x, cy - radius);
-    ctx.lineTo(x, cy + radius);
-    ctx.stroke();
-  }
-  for (let gy = -gridCount; gy <= gridCount; gy += 1) {
-    const y = cy + gy * spacing * (NUM.SEVEN / NUM.NINE);
-    ctx.beginPath();
-    ctx.moveTo(cx - radius, y);
-    ctx.lineTo(cx + radius, y);
-    ctx.stroke();
+  ctx.strokeStyle = palette.layers[5];
+  ctx.lineWidth = Math.max(1.2, radius / NUM.NINETYNINE * NUM.SEVEN);
+  for (let i = 1; i <= ringCount; i += 1) {
+    const ringRadius = radius * (1 + i / (ringCount + NUM.THREE));
+    drawCircle(ctx, centerX, centerY, ringRadius, { stroke: true });
   }
 
+  // Vesica grid anchored to a 3x3 lattice keeps the base calm and symmetric.
+  const gridSteps = NUM.THREE;
+  const extent = radius * (NUM.ELEVEN / NUM.NINE);
+  ctx.globalAlpha = 0.16;
+  for (let i = -gridSteps; i <= gridSteps; i += 1) {
+    const offsetX = (i / gridSteps) * extent;
+    drawLine(ctx, centerX + offsetX, centerY - extent, centerX + offsetX, centerY + extent);
+    const offsetY = (i / gridSteps) * extent;
+    drawLine(ctx, centerX - extent, centerY + offsetY, centerX + extent, centerY + offsetY);
+  }
   ctx.restore();
 }
 
-function drawTreeOfLife(ctx, { width, height, lineColor, nodeColor, NUM }) {
-  const topMargin = height / NUM.TWENTYTWO * NUM.THREE;
-  const verticalSpan = height - topMargin * 2;
-  const verticalStep = verticalSpan / NUM.SEVEN;
-  const lateralSpread = width / NUM.THREE;
-  const centerX = width / 2;
-
-  const nodes = [
-    { id: "keter", x: centerX, y: topMargin },
-    { id: "chokmah", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep },
-    { id: "binah", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep },
-    { id: "chesed", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
-    { id: "gevurah", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 2 },
-    { id: "tiferet", x: centerX, y: topMargin + verticalStep * 3 },
-    { id: "netzach", x: centerX + lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
-    { id: "hod", x: centerX - lateralSpread / NUM.THREE, y: topMargin + verticalStep * 4 },
-    { id: "yesod", x: centerX, y: topMargin + verticalStep * 5 },
-    { id: "malkuth", x: centerX, y: topMargin + verticalStep * 6 }
-  ];
-
-  const nodeMap = new Map();
-  for (let i = 0; i < nodes.length; i += 1) {
-    nodeMap.set(nodes[i].id, nodes[i]);
-  }
-
-  const paths = [
-    ["keter", "chokmah"],
-    ["keter", "binah"],
-    ["keter", "tiferet"],
-    ["chokmah", "binah"],
-    ["chokmah", "chesed"],
-    ["chokmah", "tiferet"],
-    ["binah", "gevurah"],
-    ["binah", "tiferet"],
-    ["chesed", "gevurah"],
-    ["chesed", "tiferet"],
-    ["chesed", "netzach"],
-    ["gevurah", "tiferet"],
-    ["gevurah", "hod"],
-    ["tiferet", "netzach"],
-    ["tiferet", "hod"],
-    ["tiferet", "yesod"],
-    ["netzach", "hod"],
-    ["netzach", "yesod"],
-    ["hod", "yesod"],
-    ["netzach", "malkuth"],
-    ["hod", "malkuth"],
-    ["yesod", "malkuth"]
-  ];
-
-  ctx.save();
-  ctx.globalAlpha = 0.6;
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = Math.max(1.2, width / (NUM.ONEFORTYFOUR * 1.2));
-  for (let i = 0; i < paths.length; i += 1) {
-    const [startId, endId] = paths[i];
-    const start = nodeMap.get(startId);
-    const end = nodeMap.get(endId);
-    if (!start || !end) {
-      continue;
 function paintTreeOfLife(ctx, { width, height, palette, NUM }) {
-  const nodes = getTreeNodes({ width, height, NUM });
-  const paths = getTreePaths();
-  const strokeScaled = Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE);
-  const strokeWidth = Math.max(NUM.THIRTYTHREE / NUM.TWENTYTWO, strokeScaled);
-  const radiusScaled = Math.min(width, height) / (NUM.NINETYNINE / NUM.THREE);
-  const nodeRadius = Math.max(NUM.THREE * (NUM.TWENTYTWO / NUM.ELEVEN), radiusScaled);
+  const nodes = buildTreeNodes(width, height, NUM);
+  const paths = buildTreePaths();
+  const strokeWidth = Math.max(1.4, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE));
+  const nodeRadius = Math.max(6, Math.min(width, height) / (NUM.NINETYNINE / NUM.THREE));
 
   ctx.save();
   ctx.globalAlpha = 0.68;
   ctx.strokeStyle = palette.layers[2];
   ctx.lineWidth = strokeWidth;
-  paths.forEach(([from, to]) => {
-    const start = nodes[from];
-    const end = nodes[to];
-    if (!start || !end) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(start.x, start.y);
-    ctx.lineTo(end.x, end.y);
-    ctx.stroke();
+  for (let i = 0; i < paths.length; i += 1) {
+    const [fromIndex, toIndex] = paths[i];
+    const start = nodes[fromIndex];
+    const end = nodes[toIndex];
+    drawLine(ctx, start.x, start.y, end.x, end.y);
   }
 
-  ctx.globalAlpha = 0.88;
-  const nodeRadius = Math.max(6, width / NUM.NINETYNINE);
-  ctx.fillStyle = nodeColor;
-  ctx.strokeStyle = lineColor;
-  ctx.lineWidth = Math.max(1, nodeRadius / NUM.THIRTYTHREE * NUM.THREE);
+  // Nodes render last for clarity; halos stay gentle for ND safety.
+  ctx.globalAlpha = 0.9;
+  ctx.fillStyle = palette.ink;
+  ctx.strokeStyle = palette.layers[5];
+  ctx.lineWidth = strokeWidth / NUM.THREE;
   for (let i = 0; i < nodes.length; i += 1) {
     const node = nodes[i];
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-  }
-  });
-
-  // Nodes rendered last for clarity; gentle halos avoid harsh focus.
-  ctx.globalAlpha = 0.92;
-  ctx.fillStyle = palette.ink;
-  nodes.forEach((node) => {
     drawCircle(ctx, node.x, node.y, nodeRadius, { fill: true });
     ctx.globalAlpha = 0.55;
-    ctx.strokeStyle = palette.layers[5];
-    ctx.lineWidth = strokeWidth / NUM.THREE;
     drawCircle(ctx, node.x, node.y, nodeRadius * (NUM.THIRTYTHREE / NUM.TWENTYTWO), { stroke: true });
-    ctx.globalAlpha = 0.92;
-    ctx.strokeStyle = palette.layers[2];
-  });
-
+    ctx.globalAlpha = 0.9;
+  }
   ctx.restore();
 }
 
-function drawFibonacciCurve(ctx, { width, height, color, NUM }) {
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const maxRadius = Math.min(width, height) / NUM.THREE;
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO;
-  const rotations = NUM.ELEVEN / NUM.THREE; // 3.66 turns keeps the spiral calm.
-  const growthSteps = NUM.SEVEN;
-  const startRadius = maxRadius / Math.pow(phi, growthSteps);
-
-  ctx.save();
-  ctx.strokeStyle = color;
-  ctx.globalAlpha = 0.72;
-  ctx.lineWidth = Math.max(1.4, maxRadius / NUM.ONEFORTYFOUR * NUM.THREE);
-  ctx.beginPath();
-
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const angle = rotations * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, growthSteps * t);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-    if (i === 0) {
-      ctx.moveTo(x, y);
-    } else {
-      ctx.lineTo(x, y);
-    }
-  }
-
-  ctx.stroke();
-
-  // Anchor points along the spiral provide gentle focus points.
-  const markerCount = NUM.NINE;
-  ctx.fillStyle = color;
-  ctx.globalAlpha = 0.5;
-  const markerRadius = Math.max(3, maxRadius / NUM.ONEFORTYFOUR * NUM.THREE);
-  for (let i = 1; i <= markerCount; i += 1) {
-    const t = i / (markerCount + 1);
-    const angle = rotations * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, growthSteps * t);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-    ctx.beginPath();
-    ctx.arc(x, y, markerRadius, 0, Math.PI * 2);
-    ctx.fill();
-  }
-
-  ctx.restore();
-}
-
-function drawHelixLattice(ctx, { width, height, strandA, strandB, rungColor, NUM }) {
-  const topMargin = height / NUM.ELEVEN;
-  const helixHeight = height - topMargin * 2;
-  const centerX = width / 2;
-  const amplitude = width / NUM.NINE;
-  const steps = NUM.ONEFORTYFOUR;
-  const turns = NUM.THREE; // three full twists for symbolic balance.
-function getTreeNodes({ width, height, NUM }) {
+function buildTreeNodes(width, height, NUM) {
   const marginX = width / NUM.NINETYNINE * NUM.ELEVEN;
   const marginY = height / NUM.NINETYNINE * NUM.ELEVEN;
   const usableWidth = width - marginX * 2;
@@ -452,7 +185,8 @@ function getTreeNodes({ width, height, NUM }) {
   }));
 }
 
-function getTreePaths() {
+function buildTreePaths() {
+  // Twenty-two connections honour the sephirot pathways.
   return [
     [0, 1], [0, 2], [0, 5],
     [1, 2], [1, 3], [1, 5],
@@ -469,126 +203,101 @@ function getTreePaths() {
 function paintFibonacciCurve(ctx, { width, height, palette, NUM }) {
   const phi = (1 + Math.sqrt(5)) / 2;
   const steps = NUM.TWENTYTWO;
-  const totalTurns = NUM.NINE / NUM.THREE;
-  const totalTheta = totalTurns * Math.PI * 2;
-  const growth = Math.log(phi) / (Math.PI / 2);
-  const baseRadius = Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THIRTYTHREE;
-  const centerX = width * 0.3;
-  const centerY = height * 0.6;
-  const points = [];
+  const rotations = NUM.NINE / NUM.THREE; // Three full turns keep the spiral serene.
+  const centerX = width * (NUM.SEVEN / NUM.TWENTYTWO);
+  const centerY = height * (NUM.ELEVEN / NUM.TWENTYTWO);
+  const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE;
+  const growth = NUM.ELEVEN / NUM.SEVEN;
 
-  const pointsA = [];
-  const pointsB = [];
+  const points = [];
   for (let i = 0; i <= steps; i += 1) {
     const t = i / steps;
-    const angle = turns * Math.PI * 2 * t;
-    const y = topMargin + helixHeight * t;
-    const xA = centerX + Math.sin(angle) * amplitude;
-    const xB = centerX + Math.sin(angle + Math.PI) * amplitude;
-    pointsA.push({ x: xA, y });
-    pointsB.push({ x: xB, y });
+    const angle = rotations * Math.PI * 2 * t;
+    const radius = baseRadius * Math.pow(phi, growth * t);
+    points.push({
+      x: centerX + Math.cos(angle) * radius,
+      y: centerY + Math.sin(angle) * radius
+    });
   }
 
   ctx.save();
-  ctx.globalAlpha = 0.66;
-  ctx.lineWidth = Math.max(1.4, width / NUM.ONEFORTYFOUR * NUM.THREE);
-  drawPolyline(ctx, pointsA, strandA);
-  drawPolyline(ctx, pointsB, strandB);
-
-  // Cross rungs referencing 33 + 66 ratios for stable lattice.
-  const rungInterval = Math.max(2, Math.floor(steps / NUM.THIRTYTHREE));
-  ctx.strokeStyle = rungColor;
-  ctx.globalAlpha = 0.4;
-  ctx.lineWidth = Math.max(1, width / NUM.ONEFORTYFOUR * NUM.SEVEN / NUM.ELEVEN);
-  for (let i = 0; i <= steps; i += rungInterval) {
-    const a = pointsA[i];
-    const b = pointsB[i];
-    const theta = totalTheta * t;
-    const radius = baseRadius * Math.exp(growth * theta);
-    const x = centerX + radius * Math.cos(theta);
-    const y = centerY + radius * Math.sin(theta);
-    points.push({ x, y });
-  }
-
-  const strokeScaled = Math.min(width, height) / (NUM.ONEFORTYFOUR / (NUM.TWENTYTWO / NUM.ELEVEN));
-  const strokeWidth = Math.max(NUM.TWENTYTWO / NUM.ELEVEN, strokeScaled);
-
-  ctx.save();
-  ctx.globalAlpha = 0.9;
+  ctx.globalAlpha = 0.75;
   ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = strokeWidth;
-  tracePolyline(ctx, points);
+  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE);
+  strokePolyline(ctx, points);
+
+  // Anchor markers provide gentle focus without motion cues.
+  ctx.globalAlpha = 0.55;
+  ctx.fillStyle = palette.layers[3];
+  const markerRadius = Math.max(3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN / NUM.ELEVEN);
+  for (let i = 1; i < points.length; i += Math.max(1, Math.floor(points.length / NUM.NINE))) {
+    const point = points[i];
+    drawCircle(ctx, point.x, point.y, markerRadius, { fill: true });
+  }
   ctx.restore();
 }
 
 function paintHelixLattice(ctx, { width, height, palette, NUM }) {
-  const strandSamples = NUM.ONEFORTYFOUR;
-  const frequency = NUM.THREE;
-  const amplitude = height / NUM.THIRTYTHREE * NUM.SEVEN;
-  const midY = height / 2;
+  const samples = NUM.ONEFORTYFOUR;
+  const verticalMargin = height / NUM.ELEVEN;
+  const usableHeight = height - verticalMargin * 2;
+  const centerX = width * (NUM.ELEVEN / NUM.TWENTYTWO);
+  const amplitude = width / NUM.NINE;
+  const turns = NUM.THREE;
+
   const strandA = [];
   const strandB = [];
-
-  for (let i = 0; i <= strandSamples; i += 1) {
-    const t = i / strandSamples;
-    const theta = t * Math.PI * 2 * frequency;
-    const x = t * width;
-    strandA.push({ x, y: midY + Math.sin(theta) * amplitude });
-    strandB.push({ x, y: midY + Math.sin(theta + Math.PI) * amplitude });
+  for (let i = 0; i <= samples; i += 1) {
+    const t = i / samples;
+    const angle = turns * Math.PI * 2 * t;
+    const y = verticalMargin + usableHeight * t;
+    strandA.push({ x: centerX + Math.sin(angle) * amplitude, y });
+    strandB.push({ x: centerX + Math.sin(angle + Math.PI) * amplitude, y });
   }
-
-  const baseLine = Math.min(width, height) / NUM.ONEFORTYFOUR;
-  const lineWidth = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, baseLine);
 
   ctx.save();
-  ctx.globalAlpha = 0.78;
-  ctx.lineWidth = lineWidth;
+  ctx.globalAlpha = 0.7;
+  ctx.lineWidth = Math.max(1.3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN);
   ctx.strokeStyle = palette.layers[4];
-  tracePolyline(ctx, strandA);
+  strokePolyline(ctx, strandA);
   ctx.strokeStyle = palette.layers[5];
-  tracePolyline(ctx, strandB);
+  strokePolyline(ctx, strandB);
 
-  ctx.globalAlpha = 0.4;
+  // Cross rungs reference 33 + 66 ratios for a static lattice rhythm.
+  const rungStep = Math.max(2, Math.floor(samples / NUM.THIRTYTHREE));
+  ctx.globalAlpha = 0.45;
   ctx.strokeStyle = palette.layers[2];
-  const rungStep = Math.max(NUM.TWENTYTWO / NUM.TWENTYTWO, Math.floor(strandSamples / NUM.TWENTYTWO));
-  for (let i = 0; i <= strandSamples; i += rungStep) {
+  for (let i = 0; i <= samples; i += rungStep) {
     const a = strandA[i];
     const b = strandB[i];
-    if (!a || !b) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
+    drawLine(ctx, a.x, a.y, b.x, b.y);
   }
-
   ctx.restore();
 }
 
-function drawCircleOutline(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function drawPolyline(ctx, points, strokeStyle) {
-function drawCircle(ctx, cx, cy, radius, options = {}) {
+function drawCircle(ctx, cx, cy, radius, options) {
+  const opts = options || {};
   ctx.beginPath();
   ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  if (options.fill) {
+  if (opts.fill) {
     ctx.fill();
   }
-  if (options.stroke || !options.fill) {
+  if (opts.stroke) {
     ctx.stroke();
   }
 }
 
-function tracePolyline(ctx, points) {
-  if (!points.length) {
+function drawLine(ctx, ax, ay, bx, by) {
+  ctx.beginPath();
+  ctx.moveTo(ax, ay);
+  ctx.lineTo(bx, by);
+  ctx.stroke();
+}
+
+function strokePolyline(ctx, points) {
+  if (!Array.isArray(points) || points.length === 0) {
     return;
   }
-  ctx.strokeStyle = strokeStyle;
   ctx.beginPath();
   ctx.moveTo(points[0].x, points[0].y);
   for (let i = 1; i < points.length; i += 1) {
@@ -597,4 +306,3 @@ function tracePolyline(ctx, points) {
   }
   ctx.stroke();
 }
-


### PR DESCRIPTION
## Summary
- streamline the offline index to load the renderer once, handle palette fallbacks, and document ND-safe choices
- rebuild the helix renderer module with pure helpers for the vesica grid, Tree of Life, Fibonacci spiral, and helix lattice using numerology constants

## Testing
- node scripts/no-placeholders.mjs *(fails: script not present in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d262dba6f4832895afdb721ac9f114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Offline-safe fallback color palette for reliable rendering.
  * Clearer status messages for palette loading and rendering outcomes.
  * Static, non-animated visuals for a calmer, sensory-safe experience.

* Bug Fixes
  * Graceful handling when palette loading fails.
  * Improved messaging and behavior when canvas context is unavailable.

* Style
  * Simplified, uppercase header with adjusted margins.
  * Updated UI text to reflect offline-first, sensory-safe workflow.

* Refactor
  * Streamlined rendering flow for consistent, motionless output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->