### PR TITLE
Refine static helix renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,142 +6,99 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); padding:0 16px; text-align:center; }
-    /* ND-safe presentation: calm contrast, generous spacing, zero motion */
-  <meta name="color-scheme" content="dark light">
-  <style>
-    /* ND-safe layout: calm contrast, no motion, generous breathing room */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:14px 18px; border-bottom:1px solid #1d1d2a; box-shadow:0 1px 0 #10101a inset; }
-    h1 { margin:0; font-size:20px; letter-spacing:0.02em; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:18px auto 12px; box-shadow:0 0 0 1px #1d1d2a,0 18px 36px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 22px; color:var(--muted); padding:0 16px; text-align:center; }
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:16px 18px; border-bottom:1px solid #1d1d2a; }
-    h1 { margin:0; font-size:20px; letter-spacing:0.03em; text-transform:uppercase; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:18px auto 12px; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 24px; color:var(--muted); padding:0 16px; text-align:center; }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-    /* ND-safe: soft contrast, no motion, generous breathing room */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9fa3c8; }
-    /* ND-safe: calm contrast, generous spacing, no motion */
+    /* ND-safe styling: calm contrast, zero motion, generous whitespace */
     :root {
-      --bg:#0b0b12;
-      --ink:#e8e8f0;
-      --muted:#a6a6c1;
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #9ea2c9;
     }
 
-    html, body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+    html,
+    body {
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     }
 
     header {
-      padding:12px 16px;
-      border-bottom:1px solid #1d1d2a;
-      letter-spacing:0.02em;
+      padding: 14px 18px;
+      border-bottom: 1px solid #1d1d2a;
+      letter-spacing: 0.02em;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 20px;
     }
 
     .status {
-      color:var(--muted);
-      font-size:12px;
-      margin-top:4px;
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 12px;
     }
 
     #stage {
-      display:block;
-      margin:16px auto;
-      box-shadow:0 0 0 1px #1d1d2a,0 14px 32px rgba(0,0,0,0.32);
-      background:var(--bg);
+      display: block;
+      width: 1440px;
+      height: 900px;
+      margin: 18px auto 12px;
+      box-shadow: 0 0 0 1px #1d1d2a, 0 14px 32px rgba(0, 0, 0, 0.32);
+      background: var(--bg);
     }
 
     .note {
-      max-width:900px;
-      margin:0 auto 16px;
-      padding:0 16px;
-      color:var(--muted);
-      text-align:center;
+      max-width: 900px;
+      margin: 0 auto 24px;
+      padding: 0 16px;
+      text-align: center;
+      color: var(--muted);
     }
 
     code {
-      background:#11111a;
-      padding:2px 4px;
-      border-radius:3px;
+      background: #11111a;
+      padding: 2px 4px;
+      border-radius: 3px;
     }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-      <div class="status" id="status">Loading palette...</div>
+    <h1>Cosmic Helix Renderer</h1>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer with Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no external libraries, double-click to open offline.</p>
+  <p class="note">Static layered cosmology: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. No
+    animation, no external libraries, safe to open offline.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
     async function loadJSON(path) {
       try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          return null;
+        }
+        return await response.json();
+      } catch (error) {
         return null;
       }
     }
 
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
-
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
     const FALLBACK_PALETTE = {
       bg: "#0b0b12",
       ink: "#e8e8f0",
-      layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-    };
-
-    const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
       layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    const statusEl = document.getElementById('status');
-    const canvas = document.getElementById('stage');
-    const ctx = canvas.getContext('2d');
-
-    const fallbackPalette = {
-      bg: '#0b0b12',
-      ink: '#e8e8f0',
-      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
     };
 
-    const NUM = Object.freeze({
+    const NUMEROLOGY = Object.freeze({
       THREE: 3,
       SEVEN: 7,
       NINE: 9,
@@ -152,187 +109,21 @@
       ONEFORTYFOUR: 144
     });
 
-    function setStatus(message) {
-      statusEl.textContent = message;
-    }
+    const paletteData = await loadJSON("./data/palette.json");
+    const paletteMissing = !paletteData;
+    const palette = paletteMissing ? FALLBACK_PALETTE : paletteData;
 
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    if (!ctx) {
-      setStatus("Canvas context unavailable; rendering skipped to stay ND-safe.");
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
-      const palette = paletteData || FALLBACK_PALETTE;
-      updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
-
-      const outcome = renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      if (outcome.ok) {
-        updateStatus(paletteData ? "Rendered four static layers with custom palette." : "Rendered with fallback palette; all layers static.");
-      } else {
-        updateStatus("Render skipped: canvas context unavailable.");
-      }
-    /* Calm fallback palette preserves 4.5:1 contrast when JSON is missing. */
-    const fallbackPalette = {
-      bg: '#0b0b12',
-      ink: '#e8e8f0',
-      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#6f9bff", "#5bd6c9", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-    const activePalette = palette || defaults.palette;
-    const paletteMissing = !palette;
-
-    elStatus.textContent = paletteMissing ? "Palette missing; using safe fallback." : "Palette loaded.";
-
-    const NUM = {
-      THREE:3,
-      SEVEN:7,
-      NINE:9,
-      ELEVEN:11,
-      TWENTYTWO:22,
-      THIRTYTHREE:33,
-      NINETYNINE:99,
-      ONEFORTYFOUR:144
-    };
+    statusEl.textContent = paletteMissing
+      ? "Palette missing or unreadable; using safe fallback."
+      : "Palette loaded from data/palette.json.";
 
     renderHelix(ctx, {
-      width:canvas.width,
-      height:canvas.height,
-      palette:activePalette,
-      NUM,
-      missingPalette:paletteMissing
+      width: canvas.width,
+      height: canvas.height,
+      palette,
+      numerology: NUMEROLOGY,
+      missingPalette: paletteMissing
     });
-    statusEl.textContent = paletteData
-      ? "Palette loaded. Rendering static layers…"
-      : "Palette missing or blocked; using ND-safe fallback.";
-
-    // Single render: no animation loops keeps the scene calm and sensory-safe.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-    statusEl.textContent = paletteData
-      ? "Rendered with custom palette."
-      : "Rendered with fallback palette.";
-      const provenance = {
-        ...renderResult.render,
-        paletteSource,
-        overlay: debugOverlay ? "safe" : "none"
-      };
-      canvas.dataset.provenance = JSON.stringify(provenance);
-    const paletteData = await loadPalette("./data/palette.json");
-    const palette = paletteData || fallbackPalette;
-    updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
-
-    if (!ctx) {
-      updateStatus("Canvas context unavailable; rendering skipped.");
-    } else {
-      try {
-        renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-        updateStatus("Rendered four calm layers without motion.");
-      } catch (error) {
-        updateStatus("Renderer failed; see console for details.");
-        throw error;
-      }
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable.";
-    } else {
-      // ND-safe rationale: render once, no animation loops.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
-      elStatus.textContent = "Rendered without motion.";
-      // Single render call: preserves stillness and avoids accidental motion loops.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      updateStatus(paletteData ? "Rendered with custom palette. Motion disabled by design." : "Rendered with fallback palette. Motion disabled by design.");
-    function updateStatus(message) {
-      status.textContent = message;
-    }
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-
-    if (!ctx) {
-      updateStatus("Canvas context unavailable in this browser.");
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
-      const palette = paletteData || FALLBACK_PALETTE;
-      updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
-      const paletteSource = paletteData ? "data/palette.json" : "fallback";
-      const clearspace = renderResult.render.clearspace_px.toFixed(1);
-      const overlayNote = debugOverlay ? "Safe frame overlay on." : "Safe frame overlay off.";
-      setStatus(`Palette: ${paletteSource}. Clearspace ${clearspace}px. ${overlayNote}`);
-
-      const outcome = renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      if (outcome.ok) {
-        updateStatus(paletteData ? "Rendered four static layers with custom palette." : "Rendered with fallback palette; all layers static.");
-      } else {
-        updateStatus("Render skipped: canvas context unavailable.");
-      }
-    if (!ctx) {
-      statusEl.textContent = "Canvas context unavailable; rendering skipped.";
-    } else {
-      const palette = await loadJSON("./data/palette.json");
-      const activePalette = palette || fallbackPalette;
-      statusEl.textContent = palette
-        ? "Palette loaded. Rendering sacred layers without motion."
-        : "Palette missing or blocked; using ND-safe fallback hues.";
-
-      // ND-safe rationale: static draw, readable contrast, layered order.
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM
-      });
-    // Single render: no animation loops keeps the scene calm and sensory-safe.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-    statusEl.textContent = paletteData
-      ? "Rendered with custom palette."
-      : "Rendered with fallback palette.";
-      const provenance = {
-        ...renderResult.render,
-        paletteSource,
-        overlay: debugOverlay ? "safe" : "none"
-      };
-      canvas.dataset.provenance = JSON.stringify(provenance);
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: 'no-store' });
-        if (!response.ok) {
-          throw new Error('Palette not accessible');
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    const paletteData = await loadPalette('./data/palette.json');
-    const activePalette = paletteData || fallbackPalette;
-    setStatus(paletteData ? 'Palette loaded. Rendering static layers…' : 'Palette missing or blocked; using ND-safe fallback.');
-
-    if (!ctx) {
-      setStatus('Canvas context unavailable; ND-safe fallback triggered.');
-    } else {
-      // Single render call keeps the canvas motionless and sensory-safe.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });
-      setStatus('Rendered calm layered geometry without motion.');
-    }
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,60 +1,23 @@
 /*
   helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry.
+  Static, ND-safe renderer for the Cosmic Helix canvas.
 
-  Layer order is intentional:
-    1) Vesica field provides the breathing lattice (soft stroke, no fill).
-    2) Tree-of-Life scaffold anchors numerology with 10 nodes and 22 paths.
-    3) Fibonacci curve adds growth arc (static polyline, no motion).
-    4) Double-helix lattice crowns the scene with mirrored strands.
+  Layer order preserves sensory calm and sacred depth:
+    1) Vesica field (interlocking circles as the grounding lattice)
+    2) Tree-of-Life scaffold (ten sephirot, twenty-two connective paths)
+    3) Fibonacci curve (phi-guided spiral drawn once, no motion)
+    4) Double helix lattice (two mirrored strands with steady crossbars)
 
-  All strokes stay inside a 8-10% margin so sacred forms keep clearspace.
-  Small pure helpers keep readability and make offline maintenance simple.
+  All helpers are pure and deterministic so offline edits stay predictable.
 */
 
 const DEFAULT_PALETTE = Object.freeze({
   bg: "#0b0b12",
   ink: "#e8e8f0",
-  layers: ["#6f9bff","#74f1ff","#8ef7c3","#ffd27f","#f5a3ff","#d4d7ff"]
-  layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-  ND-safe static renderer for layered sacred geometry.
-
-  Layer order is intentional to preserve calm depth:
-    1. Vesica field (grounding lattice of intersecting circles)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci spiral (phi-guided curve rendered without motion)
-    4. Double helix lattice (mirrored strands sampled at 144 points)
-
-  All helpers are pure: no shared mutable state, no timers, no animation.
-*/
-
-const FALLBACK_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
+  layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
 });
 
-const DEFAULT_NUM = Object.freeze({
-const DEFAULT_NUMERLOGY = Object.freeze({
-  layers: ["#6f9bff", "#5bd6c9", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-
-  Layer hierarchy (outer to inner):
-    1. Vesica field (grounding lattice with clearspace enforcement)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci curve (phi-guided spiral, drawn once)
-    4. Double helix lattice (two phase-shifted strands plus rungs)
-
-  Every helper is a pure function that depends solely on the arguments passed in.
-  This keeps edits deterministic and prevents accidental animation loops.
-*/
-
-const DEFAULT_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#b1c7ff', '#89f7fe', '#a0ffa1', '#ffd27f', '#f5a3ff', '#d0d0e6']
-});
-
-const DEFAULT_NUM = Object.freeze({
+const DEFAULT_NUMEROLOGY = Object.freeze({
   THREE: 3,
   SEVEN: 7,
   NINE: 9,
@@ -65,92 +28,56 @@ const DEFAULT_NUM = Object.freeze({
   ONEFORTYFOUR: 144
 });
 
-const CLEARSPACE_MIN_RATIO = 0.07;
-const CLEARSPACE_MIN_PX = 24;
+const CLEARSPACE_MIN_RATIO = 0.08;
+const CLEARSPACE_MIN_PX = 48;
 const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
 
-export function renderHelix(ctx, config = {}) {
+export function renderHelix(ctx, options = {}) {
   if (!ctx) {
-    return;
+    return { ok: false, reason: "No 2d context provided." };
   }
 
-  const settings = createSettings(ctx, config);
+  const settings = createSettings(ctx, options);
 
-  drawBackground(ctx, settings);
-  if (settings.missingPalette) {
-    drawPaletteNotice(ctx, settings);
-  }
+  ctx.save();
+  resetCanvas(ctx, settings);
+
   drawVesicaField(ctx, settings);
   drawTreeOfLife(ctx, settings);
   drawFibonacciCurve(ctx, settings);
   drawHelixLattice(ctx, settings);
+
+  if (settings.missingPalette) {
+    drawPaletteNotice(ctx, settings);
+  }
+
+  ctx.restore();
+
+  return { ok: true, settings };
 }
 
-function createSettings(ctx, config) {
-  const defaultPalette = {
-    bg:"#0b0b12",
-    ink:"#e8e8f0",
-    layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+function createSettings(ctx, options) {
+  const width = sanitiseDimension(options.width, ctx.canvas ? ctx.canvas.width : 1440);
+  const height = sanitiseDimension(options.height, ctx.canvas ? ctx.canvas.height : 900);
+  const palette = normalisePalette(options.palette);
+  const numerology = normaliseNumerology(options.numerology || options.NUM);
+  const margin = Math.max(CLEARSPACE_MIN_PX, Math.min(width, height) * CLEARSPACE_MIN_RATIO);
+  const stage = {
+    x: margin,
+    y: margin,
+    width: Math.max(1, width - margin * 2),
+    height: Math.max(1, height - margin * 2)
   };
-
-  const paletteInput = config.palette || defaultPalette;
-  const palette = {
-    bg: paletteInput.bg || defaultPalette.bg,
-    ink: paletteInput.ink || defaultPalette.ink,
-    layers: ensureLayerArray(paletteInput.layers, defaultPalette.layers)
-  };
-
-  const fallbackNUM = {
-    THREE:3,
-    SEVEN:7,
-    NINE:9,
-    ELEVEN:11,
-    TWENTYTWO:22,
-    THIRTYTHREE:33,
-    NINETYNINE:99,
-    ONEFORTYFOUR:144
-  };
-
-  const NUM = config.NUM || fallbackNUM;
-  const width = config.width || (ctx.canvas ? ctx.canvas.width : 1440);
-  const height = config.height || (ctx.canvas ? ctx.canvas.height : 900);
-  const margin = Math.min(width, height) / NUM.ELEVEN;
-  const stageWidth = width - margin * 2;
-  const stageHeight = height - margin * 2;
 
   return {
     width,
     height,
-    palette.layers[3],
-    palette.layers[4],
-    palette.layers[5],
-    numerology
-  );
-  const width = sanitiseDimension(options.width, ctx.canvas.width || 1440);
-  const height = sanitiseDimension(options.height, ctx.canvas.height || 900);
-  const palette = normalisePalette(options.palette);
-  const NUM = normaliseNumerology(options.NUM);
-
-  ctx.save();
-  resetCanvas(ctx, width, height, palette.bg);
-
-  paintVesicaField(ctx, { width, height, palette, NUM });
-  paintTreeOfLife(ctx, { width, height, palette, NUM });
-  paintFibonacciCurve(ctx, { width, height, palette, NUM });
-  paintHelixLattice(ctx, { width, height, palette, NUM });
-
-  ctx.restore();
-
-  return {
-    ok: true,
     palette,
-    NUM,
-    render: {
-      width,
-      height,
-      clearspace_px: clearspace,
-      safe_frame: frame
-    }
+    numerology,
+    margin,
+    stage,
+    center: { x: width / 2, y: height / 2 },
+    missingPalette: Boolean(options.missingPalette)
   };
 }
 
@@ -164,114 +91,70 @@ function sanitiseDimension(value, fallback) {
   return 1;
 }
 
-function normalisePalette(palette) {
-  if (!palette || !Array.isArray(palette.layers)) {
-    return FALLBACK_PALETTE;
-  }
-  if (Number.isFinite(fallback) && fallback > 0) {
-    return fallback;
-  }
-  return 1;
-}
-
-function setCanvasSize(canvas, width, height) {
-  if (!canvas) {
-    return;
-  }
-  canvas.width = width;
-  canvas.height = height;
-}
-
 function normalisePalette(input) {
   if (!input) {
     return DEFAULT_PALETTE;
   }
-  const layers = Array.isArray(input.layers) && input.layers.length >= 4
-    ? input.layers.slice(0, DEFAULT_PALETTE.layers.length)
-    : DEFAULT_PALETTE.layers;
+
+  const layers = Array.isArray(input.layers)
+    ? input.layers.filter(color => typeof color === "string" && color.trim())
+    : [];
+
+  while (layers.length < DEFAULT_PALETTE.layers.length) {
+    layers.push(DEFAULT_PALETTE.layers[layers.length]);
+  }
+
   return {
     bg: typeof input.bg === "string" ? input.bg : DEFAULT_PALETTE.bg,
     ink: typeof input.ink === "string" ? input.ink : DEFAULT_PALETTE.ink,
-    layers: layers.concat(DEFAULT_PALETTE.layers).slice(0, DEFAULT_PALETTE.layers.length)
+    layers: layers.slice(0, DEFAULT_PALETTE.layers.length)
   };
 }
 
-function selectNumerology(source) {
-  if (!source) {
-    return DEFAULT_NUM;
-function normaliseNumerology(NUM) {
-  if (!NUM) {
-    return FALLBACK_NUM;
-function normaliseDimension(value, fallback) {
-  if (Number.isFinite(value) && value > 0) {
-    return value;
+function normaliseNumerology(input) {
+  if (!input) {
+    return DEFAULT_NUMEROLOGY;
   }
-  return fallback;
+
+  const output = { ...DEFAULT_NUMEROLOGY };
+  for (const key of Object.keys(DEFAULT_NUMEROLOGY)) {
+    const value = input[key];
+    if (Number.isFinite(value) && value > 0) {
+      output[key] = value;
+    }
+  }
+  return output;
 }
 
-function mergePalette(palette) {
-  if (!palette) {
-    return DEFAULT_PALETTE;
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-    palette,
-    NUM,
-    margin,
-    stageWidth,
-    stageHeight,
-    centerX: width / 2,
-    centerY: height / 2,
-    missingPalette: Boolean(config.missingPalette)
-  };
-}
-
-function drawBackground(ctx, settings) {
-  ctx.save();
-  ctx.fillStyle = color;
-function resetCanvas(ctx, width, height, background) {
-  ctx.canvas.width = width;
-  ctx.canvas.height = height;
-  ctx.lineCap = 'round';
-  ctx.lineJoin = 'round';
-  ctx.fillStyle = background;
-  ctx.fillRect(0, 0, width, height);
+function resetCanvas(ctx, settings) {
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.clearRect(0, 0, settings.width, settings.height);
   ctx.fillStyle = settings.palette.bg;
   ctx.fillRect(0, 0, settings.width, settings.height);
-  ctx.restore();
-}
-
-function drawPaletteNotice(ctx, settings) {
-  const message = "palette data missing - fallback active";
-  ctx.save();
-  ctx.fillStyle = applyAlpha(settings.palette.ink, 0.58);
-  ctx.font = "14px system-ui, sans-serif";
-  ctx.textBaseline = "top";
-  ctx.fillText(message, settings.margin, settings.margin / settings.NUM.THREE);
-  ctx.restore();
 }
 
 function drawVesicaField(ctx, settings) {
-  const rows = settings.NUM.SEVEN;
-  const cols = settings.NUM.NINE;
-  const base = Math.min(settings.stageWidth, settings.stageHeight);
-  const radius = (base / settings.NUM.THIRTYTHREE) * 2;
-  const stepX = cols > 1 ? (settings.stageWidth - radius * 2) / (cols - 1) : 0;
-  const stepY = rows > 1 ? (settings.stageHeight - radius * 2) / (rows - 1) : 0;
-  const startX = settings.margin + radius;
-  const startY = settings.margin + radius;
-  const offset = radius / settings.NUM.THREE;
+  const { stage, palette, numerology } = settings;
+  const cols = Math.max(2, Math.floor(numerology.NINE));
+  const rows = Math.max(2, Math.floor(numerology.SEVEN));
+  const field = insetRect(stage, 0.92);
+  const spacingX = cols > 1 ? field.width / (cols - 1) : field.width;
+  const spacingY = rows > 1 ? field.height / (rows - 1) : field.height;
+  const radius = Math.min(spacingX, spacingY) / 2.2;
 
   ctx.save();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[0], 0.35);
-  ctx.lineWidth = 1.2;
+  ctx.strokeStyle = palette.layers[0];
+  ctx.lineWidth = Math.max(1, stage.width / 720);
+  ctx.globalAlpha = 0.88;
 
   for (let row = 0; row < rows; row += 1) {
+    const y = field.y + row * spacingY;
     for (let col = 0; col < cols; col += 1) {
-      const cx = startX + col * stepX;
-      const cy = startY + row * stepY;
-      drawCircle(ctx, cx - offset, cy, radius);
-      drawCircle(ctx, cx + offset, cy, radius);
+      const x = field.x + col * spacingX;
+      strokeCircle(ctx, x, y, radius);
+      // Offset circle to create vesica overlap using numerology.THREE as divisor.
+      const offset = spacingX / numerology.THREE;
+      strokeCircle(ctx, x + offset / 2, y, radius);
     }
   }
 
@@ -279,666 +162,191 @@ function drawVesicaField(ctx, settings) {
 }
 
 function drawTreeOfLife(ctx, settings) {
-  const nodes = buildTreeNodes(settings);
-  const nodeMap = nodes.reduce((acc, node) => {
-    acc[node.id] = node;
-    return acc;
-  }, {});
-
-  const paths = buildTreePaths();
+  const { stage, palette, numerology } = settings;
+  const nodes = computeTreeNodes(stage);
+  const paths = computeTreePaths();
+  const nodeRadius = Math.max(6, Math.min(stage.width, stage.height) / (numerology.TWENTYTWO));
+  const pathWidth = Math.max(1.5, stage.width / (numerology.NINETYNINE));
 
   ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-}
-
-function drawVesicaField(ctx, { width, height, baseColor, accentColor, NUM }) {
-  const cx = width / 2;
-  const cy = height / 2;
-  const baseRadius = Math.min(width, height) * NUM.NINE / NUM.THIRTYTHREE;
-  const offset = baseRadius / NUM.THREE;
-
-  ctx.save();
-  ctx.globalAlpha = 0.28;
-  ctx.lineWidth = Math.max(1.25, baseRadius / NUM.NINETYNINE * NUM.SEVEN);
-  ctx.strokeStyle = baseColor;
-
-  const offsets = [
-    { x: -offset, y: 0 },
-    { x: offset, y: 0 },
-    { x: 0, y: -offset },
-    { x: 0, y: offset }
-  ];
-  offsets.forEach(({ x, y }) => {
-    drawCircle(ctx, cx + x, cy + y, baseRadius, { stroke: true });
-  });
-
-  // Gentle harmonic rings provide layered depth with no motion.
-  ctx.globalAlpha = 0.16;
-  ctx.strokeStyle = accentColor;
-  for (let i = 1; i <= NUM.SEVEN; i += 1) {
-    const ringRadius = baseRadius * (1 + i / (NUM.SEVEN + NUM.THREE));
-    drawCircle(ctx, cx, cy, ringRadius, { stroke: true });
-  }
-
-  // Vesica grid based on 3x3 symmetry anchors the eye calmly.
-  ctx.globalAlpha = 0.12;
-  const gridExtent = baseRadius * (NUM.ELEVEN / NUM.NINE);
-  const gridSteps = NUM.NINE;
-  ctx.strokeStyle = baseColor;
-  for (let i = -gridSteps; i <= gridSteps; i += 1) {
-    const delta = (i / gridSteps) * gridExtent;
-    drawLine(ctx, cx + delta, cy - gridExtent, cx + delta, cy + gridExtent);
-    drawLine(ctx, cx - gridExtent, cy + delta, cx + gridExtent, cy + delta);
-function drawSafeFrame(ctx, frame, { palette, clearspace, NUM }) {
-  ctx.save();
-  const rectColor = withAlpha(palette.ink, 0.18);
-  ctx.strokeStyle = rectColor;
-  ctx.lineWidth = Math.max(1, clearspace / NUM.SEVEN);
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-
-  // Golden ratio guide lines keep exports aligned to the safe frame.
-  const v1 = frame.x + frame.width / PHI;
-  const v2 = frame.x + frame.width - frame.width / PHI;
-  const h1 = frame.y + frame.height / PHI;
-  const h2 = frame.y + frame.height - frame.height / PHI;
-function paintVesicaField(ctx, { width, height, palette, NUM }) {
-  const radius = Math.min(width, height) / NUM.THIRTYTHREE * NUM.NINE;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const offset = radius * (NUM.SEVEN / NUM.TWENTYTWO);
-
-  ctx.setLineDash([clearspace / NUM.ELEVEN, clearspace / NUM.ELEVEN]);
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.22);
-  ctx.lineWidth = Math.max(1, clearspace / NUM.TWENTYTWO);
-
-  ctx.beginPath();
-  ctx.moveTo(v1, frame.y);
-  ctx.lineTo(v1, frame.y + frame.height);
-  ctx.moveTo(v2, frame.y);
-  ctx.lineTo(v2, frame.y + frame.height);
-  ctx.moveTo(frame.x, h1);
-  ctx.lineTo(frame.x + frame.width, h1);
-  ctx.moveTo(frame.x, h2);
-  ctx.lineTo(frame.x + frame.width, h2);
-  ctx.stroke();
-
-  ctx.restore();
-}
-
-function drawVesicaField(ctx, frame, { palette, clearspace, NUM }) {
-  ctx.save();
-
-  const centerX = frame.x + frame.width / 2;
-  const centerY = frame.y + frame.height / 2;
-  const radius = Math.min(frame.width, frame.height) / (2 + 1 / NUM.THREE);
-  const strokeWidth = Math.min(clearspace * 0.9, Math.max(2, radius / NUM.NINETYNINE * NUM.SEVEN));
-
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.6);
-  ctx.lineWidth = strokeWidth;
-
-  const offsets = [
-    { x: -radius / NUM.THREE, y: 0 },
-    { x: radius / NUM.THREE, y: 0 },
-    { x: 0, y: -radius / NUM.THREE },
-    { x: 0, y: radius / NUM.THREE }
-  ];
-
-  for (const offset of offsets) {
-    drawCircle(ctx, centerX + offset.x, centerY + offset.y, radius);
-  }
-
-  // Harmonic rings reinforce depth without animation.
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.35);
-  for (let i = 1; i <= NUM.SEVEN; i += 1) {
-    const ringRadius = radius * (1 + i / (NUM.SEVEN + NUM.THREE));
-    drawCircle(ctx, centerX, centerY, ringRadius);
-  }
-
-  // Vesica grid anchored to 3x3 intersections.
-  const gridExtent = radius * (NUM.ELEVEN / NUM.NINE);
-  const gridStroke = Math.max(1, strokeWidth * 0.4);
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.22);
-  ctx.lineWidth = gridStroke;
-
-  for (let i = -NUM.NINE; i <= NUM.NINE; i += 1) {
-    const offset = (i / NUM.NINE) * gridExtent;
-    ctx.beginPath();
-    ctx.moveTo(centerX + offset, centerY - gridExtent);
-    ctx.lineTo(centerX + offset, centerY + gridExtent);
-    ctx.stroke();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[1], 0.6);
-  ctx.lineWidth = 2.2;
-
-  paths.forEach(pair => {
-    const a = nodeMap[pair[0]];
-    const b = nodeMap[pair[1]];
-    if (!a || !b) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  ctx.globalAlpha = 0.26;
-  ctx.fillStyle = palette.layers[0];
-  drawCircle(ctx, centerX - offset, centerY, radius, { fill: true });
-  ctx.fillStyle = palette.layers[1];
-  drawCircle(ctx, centerX + offset, centerY, radius, { fill: true });
-
-  // Rings use numerology ratios to hold depth without motion.
-  const ringCount = NUM.SEVEN;
-  ctx.globalAlpha = 0.18;
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(1.2, radius / NUM.NINETYNINE * NUM.SEVEN);
-  for (let i = 1; i <= ringCount; i += 1) {
-    const ringRadius = radius * (1 + i / (ringCount + NUM.THREE));
-    drawCircle(ctx, centerX, centerY, ringRadius, { stroke: true });
-  }
-
-  // Vesica grid anchored to a 3x3 lattice keeps the base calm and symmetric.
-  const gridSteps = NUM.THREE;
-  const extent = radius * (NUM.ELEVEN / NUM.NINE);
-  ctx.globalAlpha = 0.16;
-  for (let i = -gridSteps; i <= gridSteps; i += 1) {
-    const offsetX = (i / gridSteps) * extent;
-    drawLine(ctx, centerX + offsetX, centerY - extent, centerX + offsetX, centerY + extent);
-    const offsetY = (i / gridSteps) * extent;
-    drawLine(ctx, centerX - extent, centerY + offsetY, centerX + extent, centerY + offsetY);
-  }
-  ctx.restore();
-}
-
-function drawTreeOfLife(ctx, { width, height, lineColor, haloColor, nodeColor, NUM }) {
-  const nodes = getTreeNodes({ width, height, NUM });
-  const paths = getTreePaths();
-
-  ctx.save();
-  ctx.globalAlpha = 0.72;
-  ctx.strokeStyle = lineColor;
-  const pathWidth = Math.max(1.4, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.SEVEN));
   ctx.lineWidth = pathWidth;
-  paths.forEach(([from, to]) => {
   ctx.strokeStyle = palette.layers[1];
-  ctx.lineWidth = pathWidth;
-  paths.forEach(([from, to]) => {
-    const start = nodes[from];
-    const end = nodes[to];
-    if (!start || !end) {
-      continue;
-    }
-    drawLine(ctx, start.x, start.y, end.x, end.y);
-  });
+  ctx.globalAlpha = 0.9;
 
-  ctx.fillStyle = settings.palette.bg;
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[1], 0.9);
-  const nodeRadius = (Math.min(settings.stageWidth, settings.stageHeight) / settings.NUM.ONEFORTYFOUR) * settings.NUM.THREE;
+  for (const [fromIndex, toIndex] of paths) {
+    const from = nodes[fromIndex];
+    const to = nodes[toIndex];
+    ctx.beginPath();
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
+    ctx.stroke();
+  }
 
-  nodes.forEach(node => {
+  ctx.fillStyle = palette.layers[2];
+  ctx.strokeStyle = palette.ink;
+  ctx.lineWidth = Math.max(1, pathWidth / 2);
+
+  for (const node of nodes) {
     ctx.beginPath();
     ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
     ctx.fill();
     ctx.stroke();
-  });
+  }
 
   ctx.restore();
 }
 
-function buildTreeNodes(settings) {
-  const yBuffer = settings.stageHeight / settings.NUM.TWENTYTWO;
-  const xBuffer = settings.stageWidth / settings.NUM.THIRTYTHREE;
-  const scale = (settings.stageHeight - yBuffer * 2) / settings.NUM.NINE;
-  const basePositions = [0,1,1,3,3,4.5,6,6,7.5,9];
-  const leftX = settings.margin + xBuffer;
-  const rightX = settings.width - settings.margin - xBuffer;
-  const centerX = settings.centerX;
-
-  return [
-    { id:"keter", x:centerX, y:settings.margin + yBuffer + basePositions[0] * scale },
-    { id:"chokmah", x:rightX, y:settings.margin + yBuffer + basePositions[1] * scale },
-    { id:"binah", x:leftX, y:settings.margin + yBuffer + basePositions[2] * scale },
-    { id:"chesed", x:rightX, y:settings.margin + yBuffer + basePositions[3] * scale },
-    { id:"geburah", x:leftX, y:settings.margin + yBuffer + basePositions[4] * scale },
-    { id:"tiphareth", x:centerX, y:settings.margin + yBuffer + basePositions[5] * scale },
-    { id:"netzach", x:rightX, y:settings.margin + yBuffer + basePositions[6] * scale },
-    { id:"hod", x:leftX, y:settings.margin + yBuffer + basePositions[7] * scale },
-    { id:"yesod", x:centerX, y:settings.margin + yBuffer + basePositions[8] * scale },
-    { id:"malkuth", x:centerX, y:settings.margin + yBuffer + basePositions[9] * scale }
+function computeTreeNodes(stage) {
+  const layout = [
+    { x: 0.5, y: 0.04 }, // Keter
+    { x: 0.78, y: 0.16 }, // Chokmah
+    { x: 0.22, y: 0.16 }, // Binah
+    { x: 0.8, y: 0.34 }, // Chesed
+    { x: 0.2, y: 0.34 }, // Gevurah
+    { x: 0.5, y: 0.48 }, // Tiferet
+    { x: 0.82, y: 0.64 }, // Netzach
+    { x: 0.18, y: 0.64 }, // Hod
+    { x: 0.5, y: 0.78 }, // Yesod
+    { x: 0.5, y: 0.92 }  // Malkuth
   ];
+
+  return layout.map(point => ({
+    x: stage.x + point.x * stage.width,
+    y: stage.y + point.y * stage.height
+  }));
 }
 
-function buildTreePaths() {
+function computeTreePaths() {
   return [
-    ["keter","chokmah"],
-    ["keter","binah"],
-    ["chokmah","binah"],
-    ["chokmah","chesed"],
-    ["binah","geburah"],
-    ["chesed","geburah"],
-    ["chesed","tiphareth"],
-    ["geburah","tiphareth"],
-    ["chesed","netzach"],
-    ["geburah","hod"],
-    ["netzach","hod"],
-    ["netzach","yesod"],
-    ["hod","yesod"],
-    ["yesod","malkuth"],
-    ["tiphareth","netzach"],
-    ["tiphareth","hod"],
-    ["tiphareth","yesod"],
-    ["keter","tiphareth"],
-    ["binah","tiphareth"],
-    ["chokmah","tiphareth"],
-    ["netzach","malkuth"],
-    ["hod","malkuth"]
+    [0, 1], [0, 2], [1, 2],
+    [1, 3], [1, 5], [2, 4], [2, 5],
+    [3, 4], [3, 5], [4, 5],
+    [3, 6], [3, 8], [4, 7], [4, 8],
+    [5, 6], [5, 7], [6, 7],
+    [6, 8], [7, 8], [6, 9], [7, 9], [8, 9]
   ];
 }
 
 function drawFibonacciCurve(ctx, settings) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = settings.NUM.THREE;
-  const samples = settings.NUM.NINETYNINE;
-  const maxRadius = Math.min(settings.stageWidth, settings.stageHeight) / 2.4;
-  const baseRadius = (maxRadius / settings.NUM.TWENTYTWO) * settings.NUM.THREE;
-  const totalAngle = Math.PI * 2 * turns;
-  const growthFactor = (Math.PI * 2) / settings.NUM.ELEVEN;
-  const points = [];
+  const { stage, palette, numerology, center } = settings;
+  const steps = Math.max(12, Math.floor(numerology.NINETYNINE));
+  const angleIncrement = Math.PI / numerology.ELEVEN;
+  const maxRadius = Math.min(stage.width, stage.height) * 0.46;
+  const baseRadius = maxRadius / numerology.THREE;
+  const spiralCenter = {
+    x: center.x,
+    y: stage.y + stage.height * 0.6
+  };
 
-  for (let i = 0; i <= samples; i += 1) {
-    const ratio = i / samples;
-    const angle = totalAngle * ratio - Math.PI / 2;
-    const radius = Math.min(baseRadius * Math.pow(phi, angle / growthFactor), maxRadius);
-    const x = settings.centerX + radius * Math.cos(angle);
-    const y = settings.centerY + radius * Math.sin(angle);
+  const points = [];
+  for (let index = 0; index < steps; index += 1) {
+    const angle = index * angleIncrement;
+    const growth = Math.pow(GOLDEN_RATIO, angle / Math.PI);
+    const radius = Math.min(maxRadius, baseRadius * growth);
+    const x = spiralCenter.x + Math.cos(angle) * radius;
+    const y = spiralCenter.y + Math.sin(angle) * radius;
     points.push({ x, y });
   }
 
-  ctx.save();
-  ctx.lineWidth = 2.4;
-  ctx.lineJoin = "round";
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[2], 0.9);
-  drawPolyline(ctx, points);
-  ctx.restore();
-}
-
-function drawHelixLattice(ctx, settings) {
-  const segments = settings.NUM.NINETYNINE;
-  const amplitude = (settings.stageWidth / settings.NUM.THIRTYTHREE) * (settings.NUM.SEVEN / settings.NUM.ELEVEN);
-  const verticalStep = settings.stageHeight / segments;
-  const phaseStride = (Math.PI * 2) / settings.NUM.TWENTYTWO;
-  const leftPoints = [];
-  const rightPoints = [];
-
-  for (let i = 0; i <= segments; i += 1) {
-    const y = settings.margin + i * verticalStep;
-    const phase = phaseStride * i;
-    const xLeft = settings.centerX - amplitude * Math.sin(phase);
-    const xRight = settings.centerX + amplitude * Math.sin(phase + Math.PI / settings.NUM.ELEVEN);
-    leftPoints.push({ x: xLeft, y });
-    rightPoints.push({ x: xRight, y });
-  }
-
-  ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.lineWidth = 2.2;
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[3], 0.75);
-  drawPolyline(ctx, leftPoints);
-  drawPolyline(ctx, rightPoints);
-
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[4], 0.5);
-  ctx.lineWidth = 1.4;
-  const rungStep = settings.NUM.ELEVEN;
-  for (let i = 0; i < leftPoints.length; i += rungStep) {
-    const a = leftPoints[i];
-    const b = rightPoints[i];
-    if (!a || !b) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
-
-  ctx.restore();
-
-  ctx.save();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[5], 0.45);
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(settings.centerX, settings.margin);
-  ctx.lineTo(settings.centerX, settings.height - settings.margin);
-  ctx.stroke();
-
-  ctx.globalAlpha = 0.5;
-  ctx.fillStyle = marker;
-  const markerCount = NUM.SEVEN;
-  const markerRadius = Math.max(3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE);
-  for (let i = 1; i <= markerCount; i += 1) {
-    const t = i / (markerCount + 1);
-    const angle = turns * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, NUM.SEVEN * t);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-    drawCircle(ctx, x, y, markerRadius, { fill: true });
-
-    ctx.fillStyle = palette.ink;
-    ctx.strokeStyle = withAlpha(palette.layers[1], 0.7);
-    ctx.lineWidth = Math.max(1, clearspace / NUM.NINETYNINE * NUM.SEVEN);
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius * 0.55, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-function paintTreeOfLife(ctx, { width, height, palette, NUM }) {
-  const nodes = buildTreeNodes(width, height, NUM);
-  const paths = buildTreePaths();
-  const strokeWidth = Math.max(1.4, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE));
-  const nodeRadius = Math.max(6, Math.min(width, height) / (NUM.NINETYNINE / NUM.THREE));
-
-  ctx.save();
-  ctx.globalAlpha = 0.68;
-  ctx.strokeStyle = palette.layers[2];
-  ctx.lineWidth = strokeWidth;
-  for (let i = 0; i < paths.length; i += 1) {
-    const [fromIndex, toIndex] = paths[i];
-    const start = nodes[fromIndex];
-    const end = nodes[toIndex];
-    drawLine(ctx, start.x, start.y, end.x, end.y);
-  }
-
-  // Nodes render last for clarity; halos stay gentle for ND safety.
-  ctx.globalAlpha = 0.9;
-  ctx.fillStyle = palette.ink;
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = strokeWidth / NUM.THREE;
-  for (let i = 0; i < nodes.length; i += 1) {
-    const node = nodes[i];
-    drawCircle(ctx, node.x, node.y, nodeRadius, { fill: true });
-    ctx.globalAlpha = 0.55;
-    drawCircle(ctx, node.x, node.y, nodeRadius * (NUM.THIRTYTHREE / NUM.TWENTYTWO), { stroke: true });
-    ctx.globalAlpha = 0.9;
-  }
-  ctx.restore();
-}
-
-function getTreeNodes({ width, height, NUM }) {
-  const marginX = width / NUM.TWENTYTWO * (NUM.THIRTYTHREE / NUM.TWENTYTWO);
-  const marginY = height / NUM.TWENTYTWO * (NUM.THIRTYTHREE / NUM.TWENTYTWO);
-function buildTreeNodes(width, height, NUM) {
-  const marginX = width / NUM.NINETYNINE * NUM.ELEVEN;
-  const marginY = height / NUM.NINETYNINE * NUM.ELEVEN;
-  const usableWidth = width - marginX * 2;
-  const usableHeight = height - marginY * 2;
-  const layout = [
-    { u: 0.5, v: 0.02 },
-    { u: 0.72, v: 0.14 },
-    { u: 0.28, v: 0.14 },
-    { u: 0.72, v: 0.3 },
-    { u: 0.28, v: 0.3 },
-    { u: 0.5, v: 0.46 },
-    { u: 0.78, v: 0.62 },
-    { u: 0.22, v: 0.62 },
-    { u: 0.5, v: 0.78 },
-    { u: 0.5, v: 0.94 }
-  ];
-  return layout.map((pos) => ({
-    x: marginX + pos.u * usableWidth,
-    y: marginY + pos.v * usableHeight
-  }));
-}
-
-function buildTreePaths() {
-  // Twenty-two connections honour the sephirot pathways.
-  return [
-    [0, 1], [0, 2], [0, 5],
-    [1, 2], [1, 3], [1, 5],
-    [2, 4], [2, 5],
-    [3, 4], [3, 5], [3, 6],
-    [4, 5], [4, 7],
-    [5, 6], [5, 7], [5, 8],
-    [6, 8], [6, 9],
-    [7, 8], [7, 9],
-    [8, 9], [6, 7]
-  ];
-}
-
-function tracePolyline(ctx, points, strokeStyle, lineWidth) {
-  if (!points.length) {
-  ctx.restore();
-}
-
-function drawPolyline(ctx, points) {
-  if (!points || points.length === 0) {
+  if (points.length < 2) {
     return;
   }
+
+  ctx.save();
+  ctx.strokeStyle = palette.layers[3];
+  ctx.lineWidth = Math.max(1, stage.width / 960);
   ctx.beginPath();
   ctx.moveTo(points[0].x, points[0].y);
   for (let i = 1; i < points.length; i += 1) {
     ctx.lineTo(points[i].x, points[i].y);
   }
   ctx.stroke();
-}
-
-function drawCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function ensureLayerArray(layers, fallback) {
-  const base = Array.isArray(layers) ? layers.slice(0) : [];
-  for (let i = 0; i < fallback.length; i += 1) {
-    if (!base[i]) {
-      base[i] = fallback[i];
-    }
-  }
-  return base.slice(0, fallback.length);
-}
-
-function drawHelixLattice(ctx, frame, { palette, NUM }) {
-  ctx.save();
-
-  const samples = NUM.ONEFORTYFOUR;
-  const centerY = frame.y + frame.height / 2;
-  const amplitude = frame.height / (NUM.THREE + NUM.SEVEN / NUM.TWENTYTWO);
-  const angleMultiplier = Math.PI * (NUM.THREE + NUM.ELEVEN / NUM.TWENTYTWO);
-
-  const strandA = [];
-  const strandB = [];
-  for (let i = 0; i < samples; i += 1) {
-    const t = i / (samples - 1);
-    const x = frame.x + t * frame.width;
-    const angle = t * angleMultiplier;
-    strandA.push({ x, y: centerY + Math.sin(angle) * amplitude });
-    strandB.push({ x, y: centerY + Math.sin(angle + Math.PI) * amplitude });
-function paintFibonacciCurve(ctx, { width, height, palette, NUM }) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO;
-  const rotations = NUM.NINE / NUM.THREE; // Three full turns keep the spiral serene.
-  const centerX = width * (NUM.SEVEN / NUM.TWENTYTWO);
-  const centerY = height * (NUM.ELEVEN / NUM.TWENTYTWO);
-  const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE;
-  const growth = NUM.ELEVEN / NUM.SEVEN;
-
-  const points = [];
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const angle = rotations * Math.PI * 2 * t;
-    const radius = baseRadius * Math.pow(phi, growth * t);
-    points.push({
-      x: centerX + Math.cos(angle) * radius,
-      y: centerY + Math.sin(angle) * radius
-    });
-  }
-
-  ctx.save();
-  ctx.globalAlpha = 0.75;
-  ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE);
-  strokePolyline(ctx, points);
-
-  // Anchor markers provide gentle focus without motion cues.
-  ctx.globalAlpha = 0.55;
-  ctx.fillStyle = palette.layers[3];
-  const markerRadius = Math.max(3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN / NUM.ELEVEN);
-  for (let i = 1; i < points.length; i += Math.max(1, Math.floor(points.length / NUM.NINE))) {
-    const point = points[i];
-    drawCircle(ctx, point.x, point.y, markerRadius, { fill: true });
-  }
   ctx.restore();
 }
 
-function paintHelixLattice(ctx, { width, height, palette, NUM }) {
-  const samples = NUM.ONEFORTYFOUR;
-  const verticalMargin = height / NUM.ELEVEN;
-  const usableHeight = height - verticalMargin * 2;
-  const centerX = width * (NUM.ELEVEN / NUM.TWENTYTWO);
-  const amplitude = width / NUM.NINE;
-  const turns = NUM.THREE;
+function drawHelixLattice(ctx, settings) {
+  const { stage, palette, numerology } = settings;
+  const samples = Math.max(12, Math.floor(numerology.ONEFORTYFOUR));
+  const amplitude = stage.width / numerology.SEVEN;
+  const verticalStep = stage.height / (samples - 1);
+  const frequency = (Math.PI * 2) / numerology.THIRTYTHREE;
 
   const strandA = [];
   const strandB = [];
-  for (let i = 0; i <= samples; i += 1) {
-    const t = i / samples;
-    const angle = turns * Math.PI * 2 * t;
-    const y = verticalMargin + usableHeight * t;
-    strandA.push({ x: centerX + Math.sin(angle) * amplitude, y });
-    strandB.push({ x: centerX + Math.sin(angle + Math.PI) * amplitude, y });
-  }
-  return points;
-function applyAlpha(hex, alpha) {
-  const rgb = hexToRgb(hex);
-  const safeAlpha = Math.max(0, Math.min(alpha, 1));
-  return "rgba(" + rgb.r + "," + rgb.g + "," + rgb.b + "," + safeAlpha + ")";
-}
 
-function hexToRgb(hex) {
-  if (!hex) {
-    return { r: 232, g: 232, b: 240 };
+  for (let index = 0; index < samples; index += 1) {
+    const y = stage.y + index * verticalStep;
+    const angle = index * frequency;
+    const xA = stage.x + stage.width / 2 + Math.sin(angle) * amplitude;
+    const xB = stage.x + stage.width / 2 + Math.sin(angle + Math.PI) * amplitude;
+    strandA.push({ x: xA, y });
+    strandB.push({ x: xB, y });
   }
 
   ctx.save();
-  ctx.globalAlpha = 0.8;
-  ctx.strokeStyle = strandA;
-  ctx.lineWidth = 2;
-  drawPolyline(ctx, strand1);
-  ctx.strokeStyle = strandB;
-  drawPolyline(ctx, strand2);
+  ctx.lineWidth = Math.max(1.25, stage.width / 840);
+  ctx.strokeStyle = palette.layers[4];
+  strokePolyline(ctx, strandA);
+  strokePolyline(ctx, strandB);
 
-  ctx.globalAlpha = 0.4;
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1.2;
-  const rungStep = Math.max(1, Math.floor(samples / NUM.TWENTYTWO));
-  for (let i = 0; i < strand1.length; i += rungStep) {
-    const a = strand1[i];
-    const b = strand2[i];
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  const strandWidth = Math.max(1.25, frame.width / NUM.ONEFORTYFOUR * NUM.THREE / NUM.ELEVEN);
-  tracePolyline(ctx, strandA, { color: palette.layers[3], lineWidth: strandWidth, alpha: 0.7 });
-  tracePolyline(ctx, strandB, { color: palette.layers[4], lineWidth: strandWidth, alpha: 0.7 });
+  const rungInterval = Math.max(3, Math.floor(samples / numerology.TWENTYTWO));
+  ctx.strokeStyle = palette.layers[5];
+  ctx.lineWidth = Math.max(1, stage.width / 1024);
+  ctx.globalAlpha = 0.85;
 
-  ctx.strokeStyle = withAlpha(palette.layers[5], 0.45);
-  ctx.lineWidth = Math.max(1, strandWidth * 0.85);
-  const rungStep = Math.max(2, Math.floor(samples / NUM.TWENTYTWO));
-  for (let i = 0; i < samples; i += rungStep) {
-    const a = strandA[i];
-    const b = strandB[i];
+  for (let index = 0; index < samples; index += rungInterval) {
+    const a = strandA[index];
+    const b = strandB[index];
+    if (!a || !b) {
+      continue;
+    }
     ctx.beginPath();
     ctx.moveTo(a.x, a.y);
     ctx.lineTo(b.x, b.y);
     ctx.stroke();
   }
 
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
   ctx.restore();
 }
 
-function drawCircle(ctx, cx, cy, radius) {
-function drawCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function drawPolyline(ctx, points) {
-function drawCircle(ctx, cx, cy, radius, options = {}) {
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  }
-
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-  ctx.restore();
-}
-
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-  ctx.restore();
-}
-
-function drawCircle(ctx, cx, cy, radius) {
+function drawPaletteNotice(ctx, settings) {
+  const { palette, stage } = settings;
+  const y = Math.max(20, stage.y - 18);
   ctx.save();
-  ctx.globalAlpha = 0.7;
-  ctx.lineWidth = Math.max(1.3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN);
-  ctx.strokeStyle = palette.layers[4];
-  strokePolyline(ctx, strandA);
-  ctx.strokeStyle = palette.layers[5];
-  strokePolyline(ctx, strandB);
-
-  // Cross rungs reference 33 + 66 ratios for a static lattice rhythm.
-  const rungStep = Math.max(2, Math.floor(samples / NUM.THIRTYTHREE));
-  ctx.globalAlpha = 0.45;
-  ctx.strokeStyle = palette.layers[2];
-  for (let i = 0; i <= samples; i += rungStep) {
-    const a = strandA[i];
-    const b = strandB[i];
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  }
+  ctx.fillStyle = palette.ink;
+  ctx.globalAlpha = 0.72;
+  ctx.font = "13px system-ui, -apple-system, 'Segoe UI', sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText("Palette file missing — using built-in fallback.", stage.x, y);
   ctx.restore();
 }
 
-function drawCircle(ctx, cx, cy, radius, options) {
-  const opts = options || {};
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  if (opts.fill) {
-    ctx.fill();
-  }
-  if (options.stroke) {
-  if (opts.stroke) {
-    ctx.stroke();
-  }
+function insetRect(rect, factor) {
+  const clamped = Math.min(Math.max(factor, 0.1), 1);
+  const insetX = rect.width * (1 - clamped) / 2;
+  const insetY = rect.height * (1 - clamped) / 2;
+  return {
+    x: rect.x + insetX,
+    y: rect.y + insetY,
+    width: rect.width * clamped,
+    height: rect.height * clamped
+  };
 }
 
-function drawPolyline(ctx, points) {
-  if (!points.length) {
-function drawLine(ctx, ax, ay, bx, by) {
+function strokeCircle(ctx, x, y, radius) {
   ctx.beginPath();
-  ctx.moveTo(ax, ay);
-  ctx.lineTo(bx, by);
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
   ctx.stroke();
 }
 
 function strokePolyline(ctx, points) {
-  if (!Array.isArray(points) || points.length === 0) {
+  if (!points.length) {
     return;
   }
   ctx.beginPath();
   ctx.moveTo(points[0].x, points[0].y);
   for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    ctx.lineTo(point.x, point.y);
-  const raw = hex.replace("#", "");
-  const value = raw.length === 3
-    ? raw.split("").map(ch => ch + ch).join("")
-    : raw;
-  const intValue = parseInt(value, 16);
-  if (Number.isNaN(intValue)) {
-    return { r: 232, g: 232, b: 240 };
+    ctx.lineTo(points[index].x, points[index].y);
   }
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
+  ctx.stroke();
 }


### PR DESCRIPTION
## Summary
- rebuild the offline `index.html` entry to offer calm ND-safe styling, load the palette file with a safe fallback, and pass numerology constants into the renderer once without motion
- replace the helix renderer module with pure geometry helpers that draw the vesica lattice, Tree-of-Life scaffold, Fibonacci spiral, and static double helix while noting palette fallback on-canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3437493388328885d49454389ce0d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic fallback color palette if palette data is unavailable.
  - Unified rendering flow for more consistent visuals.
  - Clear status messaging indicating successful render or fallback use.

- Style
  - Consolidated theme variables with standardized spacing and typography.
  - Fixed canvas/stage dimensions for predictable layout.
  - Refined margins and shadows for a cleaner look.

- Bug Fixes
  - Prevents blank renders when palette loading fails.
  - Ensures canvas resets cleanly between renders.

- Refactor
  - Streamlined rendering pipeline for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->