### PR TITLE
feat: refresh offline helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,31 +1,30 @@
 # Cosmic Helix Renderer (Offline)
 
-Static HTML + Canvas renderer that can be opened directly without a server. It encodes the layered cosmology requested by the Cosmic-Helix spec while honoring ND-safe principles: no motion, soft yet legible contrast, and generous canvas padding.
+Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe practices: no motion, soft yet legible contrast, and layered geometry that preserves depth. Everything works offline; double-clicking `index.html` is enough.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas and a small status line for palette loading state.
-- `js/helix-renderer.mjs` - pure ES module that draws the Vesica grid, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
-- `data/palette.json` - editable ND-safe palette. If removed, the renderer falls back to an embedded palette and writes a gentle notice on-canvas.
+- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading (JSON import when opened via `file://`, `fetch` otherwise).
+- `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
+- `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
 
 ## Layer Breakdown
-1. **Vesica field** - Seven by nine lattice of intersecting circles (constants 7 and 9) to seed the sacred geometry grid without touching canvas edges.
-2. **Tree-of-Life scaffold** - Ten sephirot nodes with twenty-two connective paths. Positions are scaled by constants 3, 9, 11, and 22 for numerological resonance.
-3. **Fibonacci curve** - Static polyline approximation of a logarithmic spiral. Growth uses phi raised via constants 3, 11, 22, and 99 to keep motion-free expansion.
-4. **Double-helix lattice** - Ninety-nine point samples per strand with mirrored phase offsets (constants 7, 11, 22, 33, 99) to suggest a double helix without animation.
+1. **Vesica field** - Seven-by-nine lattice of intersecting circles (constants 7 and 9) with harmonic rings to ground the grid.
+2. **Tree-of-Life scaffold** - Ten sephirot nodes with twenty-two connective paths. Layout ratios use constants 3, 7, 9, 11, 22, 33, 99, and 144.
+3. **Fibonacci curve** - Static polyline approximation of a logarithmic spiral (phi scaled with constants 3, 11, 22, 33, 99).
+4. **Double-helix lattice** - Ninety-nine point samples per strand with mirrored phase offsets (constants 7, 11, 22, 33, 99, 144) and calm rungs.
 
 ## Palette Notes
-- Default palette favors calm blues, violets, and golds with high readability on deep charcoal.
-- Edit `data/palette.json` to adjust tones. Keep six layer colors so each geometry band can remain distinct.
+- Default palette favors serene blues, teals, gold, and violet on deep charcoal for high readability.
+- Edit `data/palette.json` to adjust tones; keep six layer colors so each geometry band remains distinct.
+- Removing the JSON file triggers the fallback palette and an inline notice, confirming the renderer is still safe.
 
 ## Using the Renderer
-1. Ensure the four files remain in place.
-2. Double-click `index.html` (or open it via File -> Open in your browser).
-3. The canvas renders instantly; no network or build steps are required.
-
-If `data/palette.json` is missing or blocked by file:// security rules, the module applies a safe fallback palette and paints a small text notice near the top margin.
+1. Keep the four files together.
+2. Double-click `index.html` (or use your browser's "Open File..." command).
+3. The canvas renders immediately; no network, build step, or workflow is required.
 
 ## Accessibility + ND-safe Choices
-- No animation, autoplay, or audio.
-- Minimum 8-10% padding keeps sacred forms from touching frame edges.
-- Calm colors respect sensory sensitivities while preserving contrast above WCAG 2.1 AA.
-- Layer order is preserved for depth: Vesica base, Tree-of-Life structure, Fibonacci growth, Helix lattice.
+- No animation, autoplay, or audio; every draw happens once.
+- Clearspace is computed from numerology constants to keep forms away from edges.
+- Palette choices sustain contrast above WCAG 2.1 AA while staying gentle on sensory systems.
+- Layer order preserves depth: Vesica base, Tree-of-Life structure, Fibonacci growth, Helix lattice crown.

--- a/index.html
+++ b/index.html
@@ -4,142 +4,91 @@
   <meta charset="utf-8">
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-  <meta name="color-scheme" content="light dark">
-  <style>
-    /* ND-safe: calm contrast, no motion, generous spacing */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
-    .status { color:var(--muted); font-size:12px; }
-    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); padding:0 16px; text-align:center; }
-    /* ND-safe presentation: calm contrast, generous spacing, zero motion */
   <meta name="color-scheme" content="dark light">
   <style>
-    /* ND-safe layout: calm contrast, no motion, generous breathing room */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:14px 18px; border-bottom:1px solid #1d1d2a; box-shadow:0 1px 0 #10101a inset; }
-    h1 { margin:0; font-size:20px; letter-spacing:0.02em; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:18px auto 12px; box-shadow:0 0 0 1px #1d1d2a,0 18px 36px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 22px; color:var(--muted); padding:0 16px; text-align:center; }
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9ea2c9; }
-    html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.5 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
-    header { padding:16px 18px; border-bottom:1px solid #1d1d2a; }
-    h1 { margin:0; font-size:20px; letter-spacing:0.03em; text-transform:uppercase; }
-    .status { color:var(--muted); font-size:12px; margin-top:4px; }
-    #stage { display:block; margin:18px auto 12px; box-shadow:0 0 0 1px #1d1d2a,0 12px 32px rgba(0,0,0,0.28); background:var(--bg); }
-    .note { max-width:900px; margin:0 auto 24px; color:var(--muted); padding:0 16px; text-align:center; }
-    code { background:#11111a; padding:2px 4px; border-radius:3px; }
-    /* ND-safe: soft contrast, no motion, generous breathing room */
-    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#9fa3c8; }
-    /* ND-safe: calm contrast, generous spacing, no motion */
+    /* ND-safe styling: calm contrast, no motion, spacious layout */
     :root {
-      --bg:#0b0b12;
-      --ink:#e8e8f0;
-      --muted:#a6a6c1;
+      --bg: #0b0b12;
+      --ink: #e8e8f0;
+      --muted: #9ea2c9;
     }
 
     html, body {
-      margin:0;
-      padding:0;
-      background:var(--bg);
-      color:var(--ink);
-      font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;
+      margin: 0;
+      padding: 0;
+      background: var(--bg);
+      color: var(--ink);
+      font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
     }
 
     header {
-      padding:12px 16px;
-      border-bottom:1px solid #1d1d2a;
-      letter-spacing:0.02em;
+      padding: 16px 20px;
+      border-bottom: 1px solid #1d1d2a;
+      box-shadow: 0 1px 0 rgba(12, 12, 20, 0.6);
+      letter-spacing: 0.02em;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 20px;
     }
 
     .status {
-      color:var(--muted);
-      font-size:12px;
-      margin-top:4px;
+      color: var(--muted);
+      font-size: 12px;
+      margin-top: 4px;
     }
 
     #stage {
-      display:block;
-      margin:16px auto;
-      box-shadow:0 0 0 1px #1d1d2a,0 14px 32px rgba(0,0,0,0.32);
-      background:var(--bg);
+      display: block;
+      width: 1440px;
+      height: 900px;
+      margin: 18px auto 12px;
+      box-shadow: 0 0 0 1px #1d1d2a, 0 16px 34px rgba(0, 0, 0, 0.28);
+      background: var(--bg);
     }
 
     .note {
-      max-width:900px;
-      margin:0 auto 16px;
-      padding:0 16px;
-      color:var(--muted);
-      text-align:center;
+      max-width: 900px;
+      margin: 0 auto 24px;
+      padding: 0 18px;
+      color: var(--muted);
+      text-align: center;
     }
 
     code {
-      background:#11111a;
-      padding:2px 4px;
-      border-radius:3px;
+      background: #11111a;
+      padding: 2px 4px;
+      border-radius: 3px;
     }
   </style>
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-      <div class="status" id="status">Loading palette...</div>
+    <h1>Cosmic Helix Renderer</h1>
+    <p class="status" id="status">Preparing static layers…</p>
   </header>
 
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static renderer with Vesica field, Tree-of-Life scaffold, Fibonacci curve, and a static double-helix lattice. No animation, no external libraries, double-click to open offline.</p>
+  <canvas
+    id="stage"
+    width="1440"
+    height="900"
+    aria-label="Layered sacred geometry canvas"
+  ></canvas>
+  <p class="note">Offline renderer for the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. Open this file directly; no network or animation occurs.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadJSON(path) {
-      try {
-        const res = await fetch(path, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return await res.json();
-      } catch (err) {
-        return null;
-      }
-    }
-
-    const defaults = {
-      palette: {
-        bg:"#0b0b12",
-        ink:"#e8e8f0",
-        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
-    };
-
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    const FALLBACK_PALETTE = {
+    const FALLBACK_PALETTE = Object.freeze({
       bg: "#0b0b12",
       ink: "#e8e8f0",
-      layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-    };
-
-    const fallbackPalette = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    const statusEl = document.getElementById('status');
-    const canvas = document.getElementById('stage');
-    const ctx = canvas.getContext('2d');
-
-    const fallbackPalette = {
-      bg: '#0b0b12',
-      ink: '#e8e8f0',
-      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-    };
+      layers: ["#88a6ff", "#7fe7f2", "#9cf5b4", "#ffd27f", "#f4a7ff", "#d6d6ed"]
+    });
 
     const NUM = Object.freeze({
       THREE: 3,
@@ -152,11 +101,22 @@
       ONEFORTYFOUR: 144
     });
 
-    function setStatus(message) {
+    function report(message) {
       statusEl.textContent = message;
     }
 
-    async function loadPalette(path) {
+    async function loadPalette() {
+      const path = "./data/palette.json";
+
+      if (window.location.protocol === "file:") {
+        try {
+          const module = await import(path, { assert: { type: "json" } });
+          return module.default;
+        } catch (error) {
+          return null;
+        }
+      }
+
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
@@ -168,171 +128,39 @@
       }
     }
 
-    if (!ctx) {
-      setStatus("Canvas context unavailable; rendering skipped to stay ND-safe.");
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
+    async function init() {
+      if (!ctx) {
+        report("Canvas context unavailable; rendering skipped to stay ND-safe.");
+        return;
+      }
+
+      const paletteData = await loadPalette();
       const palette = paletteData || FALLBACK_PALETTE;
-      updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
+      const missingPalette = !paletteData;
 
-      const outcome = renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      if (outcome.ok) {
-        updateStatus(paletteData ? "Rendered four static layers with custom palette." : "Rendered with fallback palette; all layers static.");
-      } else {
-        updateStatus("Render skipped: canvas context unavailable.");
-      }
-    /* Calm fallback palette preserves 4.5:1 contrast when JSON is missing. */
-    const fallbackPalette = {
-      bg: '#0b0b12',
-      ink: '#e8e8f0',
-      layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#6f9bff", "#5bd6c9", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-    const activePalette = palette || defaults.palette;
-    const paletteMissing = !palette;
+      report(missingPalette ? "Palette missing or blocked; using ND-safe fallback." : "Palette loaded; rendering calm layers.");
 
-    elStatus.textContent = paletteMissing ? "Palette missing; using safe fallback." : "Palette loaded.";
-
-    const NUM = {
-      THREE:3,
-      SEVEN:7,
-      NINE:9,
-      ELEVEN:11,
-      TWENTYTWO:22,
-      THIRTYTHREE:33,
-      NINETYNINE:99,
-      ONEFORTYFOUR:144
-    };
-
-    renderHelix(ctx, {
-      width:canvas.width,
-      height:canvas.height,
-      palette:activePalette,
-      NUM,
-      missingPalette:paletteMissing
-    });
-    statusEl.textContent = paletteData
-      ? "Palette loaded. Rendering static layers…"
-      : "Palette missing or blocked; using ND-safe fallback.";
-
-    // Single render: no animation loops keeps the scene calm and sensory-safe.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-    statusEl.textContent = paletteData
-      ? "Rendered with custom palette."
-      : "Rendered with fallback palette.";
-      const provenance = {
-        ...renderResult.render,
-        paletteSource,
-        overlay: debugOverlay ? "safe" : "none"
-      };
-      canvas.dataset.provenance = JSON.stringify(provenance);
-    const paletteData = await loadPalette("./data/palette.json");
-    const palette = paletteData || fallbackPalette;
-    updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
-
-    if (!ctx) {
-      updateStatus("Canvas context unavailable; rendering skipped.");
-    } else {
       try {
-        renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-        updateStatus("Rendered four calm layers without motion.");
-      } catch (error) {
-        updateStatus("Renderer failed; see console for details.");
-        throw error;
-      }
-    if (!ctx) {
-      elStatus.textContent = "Canvas context unavailable.";
-    } else {
-      // ND-safe rationale: render once, no animation loops.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: active, NUM });
-      elStatus.textContent = "Rendered without motion.";
-      // Single render call: preserves stillness and avoids accidental motion loops.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      updateStatus(paletteData ? "Rendered with custom palette. Motion disabled by design." : "Rendered with fallback palette. Motion disabled by design.");
-    function updateStatus(message) {
-      status.textContent = message;
-    }
+        const result = renderHelix(ctx, {
+          width: canvas.width,
+          height: canvas.height,
+          palette,
+          NUM,
+          missingPalette
+        });
 
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
+        if (result && result.ok) {
+          report(missingPalette ? "Rendered with fallback palette. Layers remain static." : "Rendered with custom palette. Layers remain static.");
+        } else {
+          report("Render skipped; see console for diagnostics.");
         }
-        return await response.json();
       } catch (error) {
-        return null;
-      }
-
-    if (!ctx) {
-      updateStatus("Canvas context unavailable in this browser.");
-    } else {
-      const paletteData = await loadPalette("./data/palette.json");
-      const palette = paletteData || FALLBACK_PALETTE;
-      updateStatus(paletteData ? "Palette loaded from data/palette.json." : "Palette missing; using ND-safe fallback.");
-      const paletteSource = paletteData ? "data/palette.json" : "fallback";
-      const clearspace = renderResult.render.clearspace_px.toFixed(1);
-      const overlayNote = debugOverlay ? "Safe frame overlay on." : "Safe frame overlay off.";
-      setStatus(`Palette: ${paletteSource}. Clearspace ${clearspace}px. ${overlayNote}`);
-
-      const outcome = renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-      if (outcome.ok) {
-        updateStatus(paletteData ? "Rendered four static layers with custom palette." : "Rendered with fallback palette; all layers static.");
-      } else {
-        updateStatus("Render skipped: canvas context unavailable.");
-      }
-    if (!ctx) {
-      statusEl.textContent = "Canvas context unavailable; rendering skipped.";
-    } else {
-      const palette = await loadJSON("./data/palette.json");
-      const activePalette = palette || fallbackPalette;
-      statusEl.textContent = palette
-        ? "Palette loaded. Rendering sacred layers without motion."
-        : "Palette missing or blocked; using ND-safe fallback hues.";
-
-      // ND-safe rationale: static draw, readable contrast, layered order.
-      renderHelix(ctx, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM
-      });
-    // Single render: no animation loops keeps the scene calm and sensory-safe.
-    renderHelix(ctx, { width: canvas.width, height: canvas.height, palette, NUM });
-    statusEl.textContent = paletteData
-      ? "Rendered with custom palette."
-      : "Rendered with fallback palette.";
-      const provenance = {
-        ...renderResult.render,
-        paletteSource,
-        overlay: debugOverlay ? "safe" : "none"
-      };
-      canvas.dataset.provenance = JSON.stringify(provenance);
-
-    async function loadPalette(path) {
-      try {
-        const response = await fetch(path, { cache: 'no-store' });
-        if (!response.ok) {
-          throw new Error('Palette not accessible');
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
+        console.error(error);
+        report("Renderer failed; see console for details.");
       }
     }
 
-    const paletteData = await loadPalette('./data/palette.json');
-    const activePalette = paletteData || fallbackPalette;
-    setStatus(paletteData ? 'Palette loaded. Rendering static layers…' : 'Palette missing or blocked; using ND-safe fallback.');
-
-    if (!ctx) {
-      setStatus('Canvas context unavailable; ND-safe fallback triggered.');
-    } else {
-      // Single render call keeps the canvas motionless and sensory-safe.
-      renderHelix(ctx, { width: canvas.width, height: canvas.height, palette: activePalette, NUM });
-      setStatus('Rendered calm layered geometry without motion.');
-    }
+    init();
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,57 +1,21 @@
 /*
   helix-renderer.mjs
-  ND-safe static renderer for layered sacred geometry.
+  Static, offline renderer for the layered Cosmic Helix cosmology.
 
-  Layer order is intentional:
-    1) Vesica field provides the breathing lattice (soft stroke, no fill).
-    2) Tree-of-Life scaffold anchors numerology with 10 nodes and 22 paths.
-    3) Fibonacci curve adds growth arc (static polyline, no motion).
-    4) Double-helix lattice crowns the scene with mirrored strands.
+  Layer sequence (renders from base to crown):
+    1. Vesica field (intersecting lattice) for grounding geometry.
+    2. Tree-of-Life scaffold (10 nodes, 22 paths) for structure.
+    3. Fibonacci curve (phi spiral approximation) for growth.
+    4. Double-helix lattice (mirrored strands) for crown resonance.
 
-  All strokes stay inside a 8-10% margin so sacred forms keep clearspace.
-  Small pure helpers keep readability and make offline maintenance simple.
+  ND-safe principles: no animation loops, calm contrast, generous clearspace.
+  All helpers are pure and side-effect free beyond drawing into the provided context.
 */
 
 const DEFAULT_PALETTE = Object.freeze({
   bg: "#0b0b12",
   ink: "#e8e8f0",
-  layers: ["#6f9bff","#74f1ff","#8ef7c3","#ffd27f","#f5a3ff","#d4d7ff"]
-  layers: ["#6f9bff", "#74f1ff", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-  ND-safe static renderer for layered sacred geometry.
-
-  Layer order is intentional to preserve calm depth:
-    1. Vesica field (grounding lattice of intersecting circles)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci spiral (phi-guided curve rendered without motion)
-    4. Double helix lattice (mirrored strands sampled at 144 points)
-
-  All helpers are pure: no shared mutable state, no timers, no animation.
-*/
-
-const FALLBACK_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#6f9bff', '#74f1ff', '#8ef7c3', '#ffd27f', '#f5a3ff', '#d4d7ff']
-});
-
-const DEFAULT_NUM = Object.freeze({
-const DEFAULT_NUMERLOGY = Object.freeze({
-  layers: ["#6f9bff", "#5bd6c9", "#8ef7c3", "#ffd27f", "#f5a3ff", "#d4d7ff"]
-
-  Layer hierarchy (outer to inner):
-    1. Vesica field (grounding lattice with clearspace enforcement)
-    2. Tree-of-Life scaffold (ten sephirot, twenty-two paths)
-    3. Fibonacci curve (phi-guided spiral, drawn once)
-    4. Double helix lattice (two phase-shifted strands plus rungs)
-
-  Every helper is a pure function that depends solely on the arguments passed in.
-  This keeps edits deterministic and prevents accidental animation loops.
-*/
-
-const DEFAULT_PALETTE = Object.freeze({
-  bg: '#0b0b12',
-  ink: '#e8e8f0',
-  layers: ['#b1c7ff', '#89f7fe', '#a0ffa1', '#ffd27f', '#f5a3ff', '#d0d0e6']
+  layers: ["#88a6ff", "#7fe7f2", "#9cf5b4", "#ffd27f", "#f4a7ff", "#d6d6ed"]
 });
 
 const DEFAULT_NUM = Object.freeze({
@@ -65,93 +29,317 @@ const DEFAULT_NUM = Object.freeze({
   ONEFORTYFOUR: 144
 });
 
-const CLEARSPACE_MIN_RATIO = 0.07;
-const CLEARSPACE_MIN_PX = 24;
-const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+const TREE_PATHS = Object.freeze([
+  ["keter", "chokmah"],
+  ["keter", "binah"],
+  ["chokmah", "binah"],
+  ["chokmah", "chesed"],
+  ["binah", "gevurah"],
+  ["chesed", "gevurah"],
+  ["chesed", "tiferet"],
+  ["gevurah", "tiferet"],
+  ["chesed", "netzach"],
+  ["gevurah", "hod"],
+  ["tiferet", "netzach"],
+  ["tiferet", "hod"],
+  ["netzach", "hod"],
+  ["netzach", "yesod"],
+  ["hod", "yesod"],
+  ["yesod", "malkuth"],
+  ["binah", "tiferet"],
+  ["chokmah", "tiferet"],
+  ["keter", "tiferet"],
+  ["tiferet", "yesod"],
+  ["chokmah", "netzach"],
+  ["binah", "hod"]
+]);
 
-export function renderHelix(ctx, config = {}) {
+export function renderHelix(ctx, options = {}) {
   if (!ctx) {
-    return;
+    return { ok: false, reason: "missing-context" };
   }
 
-  const settings = createSettings(ctx, config);
-
-  drawBackground(ctx, settings);
-  if (settings.missingPalette) {
-    drawPaletteNotice(ctx, settings);
-  }
-  drawVesicaField(ctx, settings);
-  drawTreeOfLife(ctx, settings);
-  drawFibonacciCurve(ctx, settings);
-  drawHelixLattice(ctx, settings);
-}
-
-function createSettings(ctx, config) {
-  const defaultPalette = {
-    bg:"#0b0b12",
-    ink:"#e8e8f0",
-    layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-  };
-
-  const paletteInput = config.palette || defaultPalette;
-  const palette = {
-    bg: paletteInput.bg || defaultPalette.bg,
-    ink: paletteInput.ink || defaultPalette.ink,
-    layers: ensureLayerArray(paletteInput.layers, defaultPalette.layers)
-  };
-
-  const fallbackNUM = {
-    THREE:3,
-    SEVEN:7,
-    NINE:9,
-    ELEVEN:11,
-    TWENTYTWO:22,
-    THIRTYTHREE:33,
-    NINETYNINE:99,
-    ONEFORTYFOUR:144
-  };
-
-  const NUM = config.NUM || fallbackNUM;
-  const width = config.width || (ctx.canvas ? ctx.canvas.width : 1440);
-  const height = config.height || (ctx.canvas ? ctx.canvas.height : 900);
-  const margin = Math.min(width, height) / NUM.ELEVEN;
-  const stageWidth = width - margin * 2;
-  const stageHeight = height - margin * 2;
-
-  return {
-    width,
-    height,
-    palette.layers[3],
-    palette.layers[4],
-    palette.layers[5],
-    numerology
-  );
-  const width = sanitiseDimension(options.width, ctx.canvas.width || 1440);
-  const height = sanitiseDimension(options.height, ctx.canvas.height || 900);
+  const width = sanitiseDimension(options.width, ctx.canvas && ctx.canvas.width ? ctx.canvas.width : 1440);
+  const height = sanitiseDimension(options.height, ctx.canvas && ctx.canvas.height ? ctx.canvas.height : 900);
   const palette = normalisePalette(options.palette);
   const NUM = normaliseNumerology(options.NUM);
 
-  ctx.save();
-  resetCanvas(ctx, width, height, palette.bg);
+  const minDimension = Math.min(width, height);
+  const clearCandidate = minDimension / NUM.ELEVEN;
+  const clearMinimum = (minDimension / NUM.ONEFORTYFOUR) * NUM.THREE;
+  const clearspace = Math.max(clearCandidate, clearMinimum);
+  const frame = createFrame(width, height, clearspace);
 
-  paintVesicaField(ctx, { width, height, palette, NUM });
-  paintTreeOfLife(ctx, { width, height, palette, NUM });
-  paintFibonacciCurve(ctx, { width, height, palette, NUM });
-  paintHelixLattice(ctx, { width, height, palette, NUM });
+  ctx.save();
+  configureContext(ctx);
+  paintBackground(ctx, width, height, palette.bg);
+
+  if (options.missingPalette) {
+    drawPaletteNotice(ctx, frame, palette, NUM);
+  }
+
+  paintVesicaField(ctx, frame, palette, NUM);
+  paintTreeOfLife(ctx, frame, palette, NUM);
+  paintFibonacciCurve(ctx, frame, palette, NUM);
+  paintHelixLattice(ctx, frame, palette, NUM);
 
   ctx.restore();
 
-  return {
-    ok: true,
-    palette,
-    NUM,
-    render: {
-      width,
-      height,
-      clearspace_px: clearspace,
-      safe_frame: frame
+  return { ok: true, palette, NUM, frame, clearspace };
+}
+
+function configureContext(ctx) {
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+}
+
+function paintBackground(ctx, width, height, color) {
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, width, height);
+}
+
+function drawPaletteNotice(ctx, frame, palette, NUM) {
+  const message = "Palette fallback active (data/palette.json missing).";
+  const padding = frame.clearspace / NUM.ONEFORTYFOUR * NUM.SEVEN;
+  const textY = frame.y + Math.max(4, frame.clearspace / NUM.ELEVEN);
+
+  ctx.save();
+  ctx.font = "14px system-ui, sans-serif";
+  ctx.textBaseline = "top";
+  const metrics = ctx.measureText(message);
+  const textWidth = metrics.width;
+  const textHeight = 18;
+
+  ctx.fillStyle = withAlpha(palette.bg, 0.85);
+  ctx.fillRect(frame.x - padding, textY - padding, textWidth + padding * 2, textHeight + padding);
+
+  ctx.fillStyle = withAlpha(palette.ink, 0.7);
+  ctx.fillText(message, frame.x, textY);
+  ctx.restore();
+}
+
+function paintVesicaField(ctx, frame, palette, NUM) {
+  const rows = NUM.SEVEN;
+  const cols = NUM.NINE;
+  const stepX = frame.width / (cols - 1);
+  const stepY = frame.height / (rows - 1);
+  const radius = Math.min(stepX, stepY) * NUM.NINE / NUM.TWENTYTWO;
+  const offset = radius / NUM.THREE;
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[0], 0.45);
+  ctx.lineWidth = Math.max(1, radius / NUM.ELEVEN);
+
+  for (let row = 0; row < rows; row += 1) {
+    for (let col = 0; col < cols; col += 1) {
+      const cx = frame.x + col * stepX;
+      const cy = frame.y + row * stepY;
+      drawCircle(ctx, cx - offset, cy, radius, { stroke: true, fill: false });
+      drawCircle(ctx, cx + offset, cy, radius, { stroke: true, fill: false });
     }
-  };
+  }
+
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[0], 0.2);
+  ctx.lineWidth = Math.max(1, radius / NUM.NINETYNINE * NUM.SEVEN);
+  const centerX = frame.x + frame.width / 2;
+  const centerY = frame.y + frame.height / 2;
+  const ringCount = NUM.SEVEN;
+  for (let index = 1; index <= ringCount; index += 1) {
+    const ringRadius = radius * (1 + index / (NUM.SEVEN + NUM.THREE));
+    drawCircle(ctx, centerX, centerY, ringRadius, { stroke: true, fill: false });
+  }
+
+  const gridSteps = NUM.NINE;
+  for (let i = 0; i <= gridSteps; i += 1) {
+    const x = frame.x + (frame.width / gridSteps) * i;
+    const y = frame.y + (frame.height / gridSteps) * i;
+    drawLine(ctx, x, frame.y, x, frame.y + frame.height);
+    drawLine(ctx, frame.x, y, frame.x + frame.width, y);
+  }
+  ctx.restore();
+}
+
+function paintTreeOfLife(ctx, frame, palette, NUM) {
+  const nodes = buildTreeNodes(frame, NUM);
+  const nodeRadius = Math.min(frame.width, frame.height) / NUM.THIRTYTHREE;
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[1], 0.6);
+  ctx.lineWidth = Math.max(1.2, nodeRadius / NUM.ELEVEN);
+  TREE_PATHS.forEach(([fromId, toId]) => {
+    const from = nodeMap.get(fromId);
+    const to = nodeMap.get(toId);
+    if (from && to) {
+      drawLine(ctx, from.x, from.y, to.x, to.y);
+    }
+  });
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.ink, 0.72);
+  ctx.fillStyle = withAlpha(palette.layers[2], 0.85);
+  ctx.lineWidth = Math.max(1, nodeRadius / NUM.THIRTYTHREE * NUM.SEVEN);
+  nodes.forEach((node) => {
+    drawCircle(ctx, node.x, node.y, nodeRadius, { stroke: true, fill: true });
+  });
+  ctx.restore();
+}
+
+function paintFibonacciCurve(ctx, frame, palette, NUM) {
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const steps = NUM.TWENTYTWO + NUM.ELEVEN;
+  const angleRange = Math.PI * (NUM.THIRTYTHREE / NUM.ELEVEN);
+  const originX = frame.x + frame.width / NUM.THREE;
+  const originY = frame.y + frame.height * (NUM.TWENTYTWO / NUM.THIRTYTHREE);
+  const scale = Math.min(frame.width, frame.height) / NUM.TWENTYTWO;
+
+  const points = [];
+  for (let index = 0; index <= steps; index += 1) {
+    const ratio = index / steps;
+    const angle = angleRange * ratio;
+    const radius = scale * Math.pow(phi, ratio * (NUM.THIRTYTHREE / NUM.NINETYNINE));
+    const x = originX + radius * Math.cos(angle);
+    const y = originY - radius * Math.sin(angle);
+    points.push({ x, y });
+  }
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[3], 0.82);
+  ctx.lineWidth = Math.max(1.5, scale / NUM.ELEVEN);
+  drawPolyline(ctx, points);
+  ctx.restore();
+
+  if (points.length > 1) {
+    ctx.save();
+    ctx.fillStyle = withAlpha(palette.layers[3], 0.9);
+    const markerRadius = Math.max(2, scale / NUM.THIRTYTHREE);
+    drawCircle(ctx, points[0].x, points[0].y, markerRadius, { stroke: false, fill: true });
+    const last = points[points.length - 1];
+    drawCircle(ctx, last.x, last.y, markerRadius, { stroke: false, fill: true });
+    ctx.restore();
+  }
+}
+
+function paintHelixLattice(ctx, frame, palette, NUM) {
+  const samples = NUM.NINETYNINE;
+  const centerX = frame.x + frame.width / 2;
+  const amplitude = frame.width / NUM.TWENTYTWO;
+  const frequency = Math.PI * (NUM.THIRTYTHREE / NUM.ELEVEN);
+  const pointsA = [];
+  const pointsB = [];
+
+  for (let index = 0; index < samples; index += 1) {
+    const t = index / (samples - 1);
+    const angle = frequency * t;
+    const y = frame.y + t * frame.height;
+    const xA = centerX + amplitude * Math.sin(angle);
+    const xB = centerX - amplitude * Math.sin(angle);
+    pointsA.push({ x: xA, y });
+    pointsB.push({ x: xB, y });
+  }
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[4], 0.7);
+  ctx.lineWidth = Math.max(1, amplitude / NUM.THIRTYTHREE);
+  drawPolyline(ctx, pointsA);
+  drawPolyline(ctx, pointsB);
+  ctx.restore();
+
+  const rungStep = Math.max(1, Math.round(samples / NUM.TWENTYTWO));
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[5], 0.45);
+  ctx.lineWidth = Math.max(1, amplitude / NUM.NINETYNINE * NUM.SEVEN);
+  for (let i = 0; i < samples; i += rungStep) {
+    const start = pointsA[i];
+    const end = pointsB[i];
+    if (start && end) {
+      drawLine(ctx, start.x, start.y, end.x, end.y);
+    }
+  }
+  ctx.restore();
+
+  ctx.save();
+  ctx.strokeStyle = withAlpha(palette.layers[5], 0.22);
+  ctx.lineWidth = Math.max(1, amplitude / NUM.ONEFORTYFOUR * NUM.SEVEN);
+  drawLine(ctx, centerX, frame.y, centerX, frame.y + frame.height);
+  ctx.restore();
+
+  const beadStep = Math.max(1, Math.round(samples / NUM.THIRTYTHREE));
+  ctx.save();
+  ctx.fillStyle = withAlpha(palette.layers[4], 0.82);
+  const beadRadius = Math.max(1.5, amplitude / NUM.ONEFORTYFOUR * NUM.SEVEN);
+  for (let i = 0; i < samples; i += beadStep) {
+    const a = pointsA[i];
+    const b = pointsB[i];
+    if (a && b) {
+      drawCircle(ctx, a.x, a.y, beadRadius, { stroke: false, fill: true });
+      drawCircle(ctx, b.x, b.y, beadRadius, { stroke: false, fill: true });
+    }
+  }
+  ctx.restore();
+}
+
+function buildTreeNodes(frame, NUM) {
+  const centerX = frame.x + frame.width / 2;
+  const offsetMajor = frame.width * NUM.SEVEN / NUM.THIRTYTHREE;
+  const offsetMinor = frame.width * NUM.THREE / NUM.THIRTYTHREE;
+  const tierSpacing = frame.height / (NUM.SEVEN + NUM.THREE);
+
+  const yKeter = frame.y + tierSpacing;
+  const ySupernal = yKeter + tierSpacing;
+  const yChesed = ySupernal + tierSpacing * (NUM.TWENTYTWO / NUM.ELEVEN);
+  const yTiferet = yChesed + tierSpacing;
+  const yNetzach = yTiferet + tierSpacing * (NUM.TWENTYTWO / NUM.ELEVEN);
+  const yYesod = yNetzach + tierSpacing;
+  const yMalkuth = yYesod + tierSpacing;
+
+  return [
+    { id: "keter", x: centerX, y: yKeter },
+    { id: "chokmah", x: centerX + offsetMajor, y: ySupernal },
+    { id: "binah", x: centerX - offsetMajor, y: ySupernal },
+    { id: "chesed", x: centerX + offsetMinor, y: yChesed },
+    { id: "gevurah", x: centerX - offsetMinor, y: yChesed },
+    { id: "tiferet", x: centerX, y: yTiferet },
+    { id: "netzach", x: centerX + offsetMinor, y: yNetzach },
+    { id: "hod", x: centerX - offsetMinor, y: yNetzach },
+    { id: "yesod", x: centerX, y: yYesod },
+    { id: "malkuth", x: centerX, y: yMalkuth }
+  ];
+}
+
+function drawCircle(ctx, x, y, radius, mode) {
+  ctx.beginPath();
+  ctx.arc(x, y, radius, 0, Math.PI * 2);
+  if (mode && mode.fill) {
+    ctx.fill();
+  }
+  if (!mode || mode.stroke) {
+    ctx.stroke();
+  }
+}
+
+function drawLine(ctx, x1, y1, x2, y2) {
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.stroke();
+}
+
+function drawPolyline(ctx, points) {
+  if (!Array.isArray(points) || points.length < 2) {
+    return;
+  }
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let index = 1; index < points.length; index += 1) {
+    ctx.lineTo(points[index].x, points[index].y);
+  }
+  ctx.stroke();
 }
 
 function sanitiseDimension(value, fallback) {
@@ -164,781 +352,71 @@ function sanitiseDimension(value, fallback) {
   return 1;
 }
 
-function normalisePalette(palette) {
-  if (!palette || !Array.isArray(palette.layers)) {
-    return FALLBACK_PALETTE;
-  }
-  if (Number.isFinite(fallback) && fallback > 0) {
-    return fallback;
-  }
-  return 1;
+function createFrame(width, height, clearspace) {
+  const safeClear = Math.min(clearspace, Math.min(width, height) / 2);
+  return {
+    x: safeClear,
+    y: safeClear,
+    width: width - safeClear * 2,
+    height: height - safeClear * 2,
+    clearspace: safeClear
+  };
 }
 
-function setCanvasSize(canvas, width, height) {
-  if (!canvas) {
-    return;
-  }
-  canvas.width = width;
-  canvas.height = height;
-}
-
-function normalisePalette(input) {
-  if (!input) {
+function normalisePalette(candidate) {
+  if (!candidate) {
     return DEFAULT_PALETTE;
   }
-  const layers = Array.isArray(input.layers) && input.layers.length >= 4
-    ? input.layers.slice(0, DEFAULT_PALETTE.layers.length)
-    : DEFAULT_PALETTE.layers;
-  return {
-    bg: typeof input.bg === "string" ? input.bg : DEFAULT_PALETTE.bg,
-    ink: typeof input.ink === "string" ? input.ink : DEFAULT_PALETTE.ink,
-    layers: layers.concat(DEFAULT_PALETTE.layers).slice(0, DEFAULT_PALETTE.layers.length)
-  };
-}
 
-function selectNumerology(source) {
-  if (!source) {
-    return DEFAULT_NUM;
-function normaliseNumerology(NUM) {
-  if (!NUM) {
-    return FALLBACK_NUM;
-function normaliseDimension(value, fallback) {
-  if (Number.isFinite(value) && value > 0) {
-    return value;
-  }
-  return fallback;
-}
-
-function mergePalette(palette) {
-  if (!palette) {
-    return DEFAULT_PALETTE;
-    bg: palette.bg || DEFAULT_PALETTE.bg,
-    ink: palette.ink || DEFAULT_PALETTE.ink,
-    layers
-    palette,
-    NUM,
-    margin,
-    stageWidth,
-    stageHeight,
-    centerX: width / 2,
-    centerY: height / 2,
-    missingPalette: Boolean(config.missingPalette)
-  };
-}
-
-function drawBackground(ctx, settings) {
-  ctx.save();
-  ctx.fillStyle = color;
-function resetCanvas(ctx, width, height, background) {
-  ctx.canvas.width = width;
-  ctx.canvas.height = height;
-  ctx.lineCap = 'round';
-  ctx.lineJoin = 'round';
-  ctx.fillStyle = background;
-  ctx.fillRect(0, 0, width, height);
-  ctx.fillStyle = settings.palette.bg;
-  ctx.fillRect(0, 0, settings.width, settings.height);
-  ctx.restore();
-}
-
-function drawPaletteNotice(ctx, settings) {
-  const message = "palette data missing - fallback active";
-  ctx.save();
-  ctx.fillStyle = applyAlpha(settings.palette.ink, 0.58);
-  ctx.font = "14px system-ui, sans-serif";
-  ctx.textBaseline = "top";
-  ctx.fillText(message, settings.margin, settings.margin / settings.NUM.THREE);
-  ctx.restore();
-}
-
-function drawVesicaField(ctx, settings) {
-  const rows = settings.NUM.SEVEN;
-  const cols = settings.NUM.NINE;
-  const base = Math.min(settings.stageWidth, settings.stageHeight);
-  const radius = (base / settings.NUM.THIRTYTHREE) * 2;
-  const stepX = cols > 1 ? (settings.stageWidth - radius * 2) / (cols - 1) : 0;
-  const stepY = rows > 1 ? (settings.stageHeight - radius * 2) / (rows - 1) : 0;
-  const startX = settings.margin + radius;
-  const startY = settings.margin + radius;
-  const offset = radius / settings.NUM.THREE;
-
-  ctx.save();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[0], 0.35);
-  ctx.lineWidth = 1.2;
-
-  for (let row = 0; row < rows; row += 1) {
-    for (let col = 0; col < cols; col += 1) {
-      const cx = startX + col * stepX;
-      const cy = startY + row * stepY;
-      drawCircle(ctx, cx - offset, cy, radius);
-      drawCircle(ctx, cx + offset, cy, radius);
-    }
-  }
-
-  ctx.restore();
-}
-
-function drawTreeOfLife(ctx, settings) {
-  const nodes = buildTreeNodes(settings);
-  const nodeMap = nodes.reduce((acc, node) => {
-    acc[node.id] = node;
-    return acc;
-  }, {});
-
-  const paths = buildTreePaths();
-
-  ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.fillStyle = color;
-  ctx.fillRect(0, 0, width, height);
-}
-
-function drawVesicaField(ctx, { width, height, baseColor, accentColor, NUM }) {
-  const cx = width / 2;
-  const cy = height / 2;
-  const baseRadius = Math.min(width, height) * NUM.NINE / NUM.THIRTYTHREE;
-  const offset = baseRadius / NUM.THREE;
-
-  ctx.save();
-  ctx.globalAlpha = 0.28;
-  ctx.lineWidth = Math.max(1.25, baseRadius / NUM.NINETYNINE * NUM.SEVEN);
-  ctx.strokeStyle = baseColor;
-
-  const offsets = [
-    { x: -offset, y: 0 },
-    { x: offset, y: 0 },
-    { x: 0, y: -offset },
-    { x: 0, y: offset }
-  ];
-  offsets.forEach(({ x, y }) => {
-    drawCircle(ctx, cx + x, cy + y, baseRadius, { stroke: true });
+  const bg = typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg;
+  const ink = typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink;
+  const layersInput = Array.isArray(candidate.layers) ? candidate.layers : [];
+  const layers = DEFAULT_PALETTE.layers.map((color, index) => {
+    const candidateColor = layersInput[index];
+    return typeof candidateColor === "string" ? candidateColor : color;
   });
 
-  // Gentle harmonic rings provide layered depth with no motion.
-  ctx.globalAlpha = 0.16;
-  ctx.strokeStyle = accentColor;
-  for (let i = 1; i <= NUM.SEVEN; i += 1) {
-    const ringRadius = baseRadius * (1 + i / (NUM.SEVEN + NUM.THREE));
-    drawCircle(ctx, cx, cy, ringRadius, { stroke: true });
-  }
-
-  // Vesica grid based on 3x3 symmetry anchors the eye calmly.
-  ctx.globalAlpha = 0.12;
-  const gridExtent = baseRadius * (NUM.ELEVEN / NUM.NINE);
-  const gridSteps = NUM.NINE;
-  ctx.strokeStyle = baseColor;
-  for (let i = -gridSteps; i <= gridSteps; i += 1) {
-    const delta = (i / gridSteps) * gridExtent;
-    drawLine(ctx, cx + delta, cy - gridExtent, cx + delta, cy + gridExtent);
-    drawLine(ctx, cx - gridExtent, cy + delta, cx + gridExtent, cy + delta);
-function drawSafeFrame(ctx, frame, { palette, clearspace, NUM }) {
-  ctx.save();
-  const rectColor = withAlpha(palette.ink, 0.18);
-  ctx.strokeStyle = rectColor;
-  ctx.lineWidth = Math.max(1, clearspace / NUM.SEVEN);
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-
-  // Golden ratio guide lines keep exports aligned to the safe frame.
-  const v1 = frame.x + frame.width / PHI;
-  const v2 = frame.x + frame.width - frame.width / PHI;
-  const h1 = frame.y + frame.height / PHI;
-  const h2 = frame.y + frame.height - frame.height / PHI;
-function paintVesicaField(ctx, { width, height, palette, NUM }) {
-  const radius = Math.min(width, height) / NUM.THIRTYTHREE * NUM.NINE;
-  const centerX = width / 2;
-  const centerY = height / 2;
-  const offset = radius * (NUM.SEVEN / NUM.TWENTYTWO);
-
-  ctx.setLineDash([clearspace / NUM.ELEVEN, clearspace / NUM.ELEVEN]);
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.22);
-  ctx.lineWidth = Math.max(1, clearspace / NUM.TWENTYTWO);
-
-  ctx.beginPath();
-  ctx.moveTo(v1, frame.y);
-  ctx.lineTo(v1, frame.y + frame.height);
-  ctx.moveTo(v2, frame.y);
-  ctx.lineTo(v2, frame.y + frame.height);
-  ctx.moveTo(frame.x, h1);
-  ctx.lineTo(frame.x + frame.width, h1);
-  ctx.moveTo(frame.x, h2);
-  ctx.lineTo(frame.x + frame.width, h2);
-  ctx.stroke();
-
-  ctx.restore();
+  return { bg, ink, layers };
 }
 
-function drawVesicaField(ctx, frame, { palette, clearspace, NUM }) {
-  ctx.save();
-
-  const centerX = frame.x + frame.width / 2;
-  const centerY = frame.y + frame.height / 2;
-  const radius = Math.min(frame.width, frame.height) / (2 + 1 / NUM.THREE);
-  const strokeWidth = Math.min(clearspace * 0.9, Math.max(2, radius / NUM.NINETYNINE * NUM.SEVEN));
-
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.6);
-  ctx.lineWidth = strokeWidth;
-
-  const offsets = [
-    { x: -radius / NUM.THREE, y: 0 },
-    { x: radius / NUM.THREE, y: 0 },
-    { x: 0, y: -radius / NUM.THREE },
-    { x: 0, y: radius / NUM.THREE }
-  ];
-
-  for (const offset of offsets) {
-    drawCircle(ctx, centerX + offset.x, centerY + offset.y, radius);
-  }
-
-  // Harmonic rings reinforce depth without animation.
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.35);
-  for (let i = 1; i <= NUM.SEVEN; i += 1) {
-    const ringRadius = radius * (1 + i / (NUM.SEVEN + NUM.THREE));
-    drawCircle(ctx, centerX, centerY, ringRadius);
-  }
-
-  // Vesica grid anchored to 3x3 intersections.
-  const gridExtent = radius * (NUM.ELEVEN / NUM.NINE);
-  const gridStroke = Math.max(1, strokeWidth * 0.4);
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.22);
-  ctx.lineWidth = gridStroke;
-
-  for (let i = -NUM.NINE; i <= NUM.NINE; i += 1) {
-    const offset = (i / NUM.NINE) * gridExtent;
-    ctx.beginPath();
-    ctx.moveTo(centerX + offset, centerY - gridExtent);
-    ctx.lineTo(centerX + offset, centerY + gridExtent);
-    ctx.stroke();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[1], 0.6);
-  ctx.lineWidth = 2.2;
-
-  paths.forEach(pair => {
-    const a = nodeMap[pair[0]];
-    const b = nodeMap[pair[1]];
-    if (!a || !b) {
-      return;
-    }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  ctx.globalAlpha = 0.26;
-  ctx.fillStyle = palette.layers[0];
-  drawCircle(ctx, centerX - offset, centerY, radius, { fill: true });
-  ctx.fillStyle = palette.layers[1];
-  drawCircle(ctx, centerX + offset, centerY, radius, { fill: true });
-
-  // Rings use numerology ratios to hold depth without motion.
-  const ringCount = NUM.SEVEN;
-  ctx.globalAlpha = 0.18;
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(1.2, radius / NUM.NINETYNINE * NUM.SEVEN);
-  for (let i = 1; i <= ringCount; i += 1) {
-    const ringRadius = radius * (1 + i / (ringCount + NUM.THREE));
-    drawCircle(ctx, centerX, centerY, ringRadius, { stroke: true });
-  }
-
-  // Vesica grid anchored to a 3x3 lattice keeps the base calm and symmetric.
-  const gridSteps = NUM.THREE;
-  const extent = radius * (NUM.ELEVEN / NUM.NINE);
-  ctx.globalAlpha = 0.16;
-  for (let i = -gridSteps; i <= gridSteps; i += 1) {
-    const offsetX = (i / gridSteps) * extent;
-    drawLine(ctx, centerX + offsetX, centerY - extent, centerX + offsetX, centerY + extent);
-    const offsetY = (i / gridSteps) * extent;
-    drawLine(ctx, centerX - extent, centerY + offsetY, centerX + extent, centerY + offsetY);
-  }
-  ctx.restore();
-}
-
-function drawTreeOfLife(ctx, { width, height, lineColor, haloColor, nodeColor, NUM }) {
-  const nodes = getTreeNodes({ width, height, NUM });
-  const paths = getTreePaths();
-
-  ctx.save();
-  ctx.globalAlpha = 0.72;
-  ctx.strokeStyle = lineColor;
-  const pathWidth = Math.max(1.4, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.SEVEN));
-  ctx.lineWidth = pathWidth;
-  paths.forEach(([from, to]) => {
-  ctx.strokeStyle = palette.layers[1];
-  ctx.lineWidth = pathWidth;
-  paths.forEach(([from, to]) => {
-    const start = nodes[from];
-    const end = nodes[to];
-    if (!start || !end) {
-      continue;
-    }
-    drawLine(ctx, start.x, start.y, end.x, end.y);
+function normaliseNumerology(source = {}) {
+  const numerology = {};
+  Object.keys(DEFAULT_NUM).forEach((key) => {
+    const value = source[key];
+    numerology[key] = Number.isFinite(value) && value > 0 ? value : DEFAULT_NUM[key];
   });
-
-  ctx.fillStyle = settings.palette.bg;
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[1], 0.9);
-  const nodeRadius = (Math.min(settings.stageWidth, settings.stageHeight) / settings.NUM.ONEFORTYFOUR) * settings.NUM.THREE;
-
-  nodes.forEach(node => {
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-  });
-
-  ctx.restore();
+  return numerology;
 }
 
-function buildTreeNodes(settings) {
-  const yBuffer = settings.stageHeight / settings.NUM.TWENTYTWO;
-  const xBuffer = settings.stageWidth / settings.NUM.THIRTYTHREE;
-  const scale = (settings.stageHeight - yBuffer * 2) / settings.NUM.NINE;
-  const basePositions = [0,1,1,3,3,4.5,6,6,7.5,9];
-  const leftX = settings.margin + xBuffer;
-  const rightX = settings.width - settings.margin - xBuffer;
-  const centerX = settings.centerX;
-
-  return [
-    { id:"keter", x:centerX, y:settings.margin + yBuffer + basePositions[0] * scale },
-    { id:"chokmah", x:rightX, y:settings.margin + yBuffer + basePositions[1] * scale },
-    { id:"binah", x:leftX, y:settings.margin + yBuffer + basePositions[2] * scale },
-    { id:"chesed", x:rightX, y:settings.margin + yBuffer + basePositions[3] * scale },
-    { id:"geburah", x:leftX, y:settings.margin + yBuffer + basePositions[4] * scale },
-    { id:"tiphareth", x:centerX, y:settings.margin + yBuffer + basePositions[5] * scale },
-    { id:"netzach", x:rightX, y:settings.margin + yBuffer + basePositions[6] * scale },
-    { id:"hod", x:leftX, y:settings.margin + yBuffer + basePositions[7] * scale },
-    { id:"yesod", x:centerX, y:settings.margin + yBuffer + basePositions[8] * scale },
-    { id:"malkuth", x:centerX, y:settings.margin + yBuffer + basePositions[9] * scale }
-  ];
+function withAlpha(color, alpha) {
+  const { r, g, b } = parseHexColor(color || "#000000");
+  return `rgba(${r}, ${g}, ${b}, ${clampAlpha(alpha)})`;
 }
 
-function buildTreePaths() {
-  return [
-    ["keter","chokmah"],
-    ["keter","binah"],
-    ["chokmah","binah"],
-    ["chokmah","chesed"],
-    ["binah","geburah"],
-    ["chesed","geburah"],
-    ["chesed","tiphareth"],
-    ["geburah","tiphareth"],
-    ["chesed","netzach"],
-    ["geburah","hod"],
-    ["netzach","hod"],
-    ["netzach","yesod"],
-    ["hod","yesod"],
-    ["yesod","malkuth"],
-    ["tiphareth","netzach"],
-    ["tiphareth","hod"],
-    ["tiphareth","yesod"],
-    ["keter","tiphareth"],
-    ["binah","tiphareth"],
-    ["chokmah","tiphareth"],
-    ["netzach","malkuth"],
-    ["hod","malkuth"]
-  ];
-}
-
-function drawFibonacciCurve(ctx, settings) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const turns = settings.NUM.THREE;
-  const samples = settings.NUM.NINETYNINE;
-  const maxRadius = Math.min(settings.stageWidth, settings.stageHeight) / 2.4;
-  const baseRadius = (maxRadius / settings.NUM.TWENTYTWO) * settings.NUM.THREE;
-  const totalAngle = Math.PI * 2 * turns;
-  const growthFactor = (Math.PI * 2) / settings.NUM.ELEVEN;
-  const points = [];
-
-  for (let i = 0; i <= samples; i += 1) {
-    const ratio = i / samples;
-    const angle = totalAngle * ratio - Math.PI / 2;
-    const radius = Math.min(baseRadius * Math.pow(phi, angle / growthFactor), maxRadius);
-    const x = settings.centerX + radius * Math.cos(angle);
-    const y = settings.centerY + radius * Math.sin(angle);
-    points.push({ x, y });
+function parseHexColor(value) {
+  if (typeof value !== "string") {
+    return { r: 0, g: 0, b: 0 };
   }
-
-  ctx.save();
-  ctx.lineWidth = 2.4;
-  ctx.lineJoin = "round";
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[2], 0.9);
-  drawPolyline(ctx, points);
-  ctx.restore();
+  const match = value.trim().match(/^#?([0-9a-fA-F]{6})$/);
+  if (!match) {
+    return { r: 0, g: 0, b: 0 };
+  }
+  const hex = match[1];
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return { r, g, b };
 }
 
-function drawHelixLattice(ctx, settings) {
-  const segments = settings.NUM.NINETYNINE;
-  const amplitude = (settings.stageWidth / settings.NUM.THIRTYTHREE) * (settings.NUM.SEVEN / settings.NUM.ELEVEN);
-  const verticalStep = settings.stageHeight / segments;
-  const phaseStride = (Math.PI * 2) / settings.NUM.TWENTYTWO;
-  const leftPoints = [];
-  const rightPoints = [];
-
-  for (let i = 0; i <= segments; i += 1) {
-    const y = settings.margin + i * verticalStep;
-    const phase = phaseStride * i;
-    const xLeft = settings.centerX - amplitude * Math.sin(phase);
-    const xRight = settings.centerX + amplitude * Math.sin(phase + Math.PI / settings.NUM.ELEVEN);
-    leftPoints.push({ x: xLeft, y });
-    rightPoints.push({ x: xRight, y });
+function clampAlpha(value) {
+  if (!Number.isFinite(value)) {
+    return 1;
   }
-
-  ctx.save();
-  ctx.lineCap = "round";
-  ctx.lineJoin = "round";
-  ctx.lineWidth = 2.2;
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[3], 0.75);
-  drawPolyline(ctx, leftPoints);
-  drawPolyline(ctx, rightPoints);
-
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[4], 0.5);
-  ctx.lineWidth = 1.4;
-  const rungStep = settings.NUM.ELEVEN;
-  for (let i = 0; i < leftPoints.length; i += rungStep) {
-    const a = leftPoints[i];
-    const b = rightPoints[i];
-    if (!a || !b) {
-      continue;
-    }
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
+  if (value < 0) {
+    return 0;
   }
-
-  ctx.restore();
-
-  ctx.save();
-  ctx.strokeStyle = applyAlpha(settings.palette.layers[5], 0.45);
-  ctx.lineWidth = 1;
-  ctx.beginPath();
-  ctx.moveTo(settings.centerX, settings.margin);
-  ctx.lineTo(settings.centerX, settings.height - settings.margin);
-  ctx.stroke();
-
-  ctx.globalAlpha = 0.5;
-  ctx.fillStyle = marker;
-  const markerCount = NUM.SEVEN;
-  const markerRadius = Math.max(3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE);
-  for (let i = 1; i <= markerCount; i += 1) {
-    const t = i / (markerCount + 1);
-    const angle = turns * Math.PI * 2 * t;
-    const radius = startRadius * Math.pow(phi, NUM.SEVEN * t);
-    const x = centerX + Math.cos(angle) * radius;
-    const y = centerY + Math.sin(angle) * radius;
-    drawCircle(ctx, x, y, markerRadius, { fill: true });
-
-    ctx.fillStyle = palette.ink;
-    ctx.strokeStyle = withAlpha(palette.layers[1], 0.7);
-    ctx.lineWidth = Math.max(1, clearspace / NUM.NINETYNINE * NUM.SEVEN);
-    ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius * 0.55, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-function paintTreeOfLife(ctx, { width, height, palette, NUM }) {
-  const nodes = buildTreeNodes(width, height, NUM);
-  const paths = buildTreePaths();
-  const strokeWidth = Math.max(1.4, Math.min(width, height) / (NUM.ONEFORTYFOUR / NUM.THREE));
-  const nodeRadius = Math.max(6, Math.min(width, height) / (NUM.NINETYNINE / NUM.THREE));
-
-  ctx.save();
-  ctx.globalAlpha = 0.68;
-  ctx.strokeStyle = palette.layers[2];
-  ctx.lineWidth = strokeWidth;
-  for (let i = 0; i < paths.length; i += 1) {
-    const [fromIndex, toIndex] = paths[i];
-    const start = nodes[fromIndex];
-    const end = nodes[toIndex];
-    drawLine(ctx, start.x, start.y, end.x, end.y);
+  if (value > 1) {
+    return 1;
   }
-
-  // Nodes render last for clarity; halos stay gentle for ND safety.
-  ctx.globalAlpha = 0.9;
-  ctx.fillStyle = palette.ink;
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = strokeWidth / NUM.THREE;
-  for (let i = 0; i < nodes.length; i += 1) {
-    const node = nodes[i];
-    drawCircle(ctx, node.x, node.y, nodeRadius, { fill: true });
-    ctx.globalAlpha = 0.55;
-    drawCircle(ctx, node.x, node.y, nodeRadius * (NUM.THIRTYTHREE / NUM.TWENTYTWO), { stroke: true });
-    ctx.globalAlpha = 0.9;
-  }
-  ctx.restore();
-}
-
-function getTreeNodes({ width, height, NUM }) {
-  const marginX = width / NUM.TWENTYTWO * (NUM.THIRTYTHREE / NUM.TWENTYTWO);
-  const marginY = height / NUM.TWENTYTWO * (NUM.THIRTYTHREE / NUM.TWENTYTWO);
-function buildTreeNodes(width, height, NUM) {
-  const marginX = width / NUM.NINETYNINE * NUM.ELEVEN;
-  const marginY = height / NUM.NINETYNINE * NUM.ELEVEN;
-  const usableWidth = width - marginX * 2;
-  const usableHeight = height - marginY * 2;
-  const layout = [
-    { u: 0.5, v: 0.02 },
-    { u: 0.72, v: 0.14 },
-    { u: 0.28, v: 0.14 },
-    { u: 0.72, v: 0.3 },
-    { u: 0.28, v: 0.3 },
-    { u: 0.5, v: 0.46 },
-    { u: 0.78, v: 0.62 },
-    { u: 0.22, v: 0.62 },
-    { u: 0.5, v: 0.78 },
-    { u: 0.5, v: 0.94 }
-  ];
-  return layout.map((pos) => ({
-    x: marginX + pos.u * usableWidth,
-    y: marginY + pos.v * usableHeight
-  }));
-}
-
-function buildTreePaths() {
-  // Twenty-two connections honour the sephirot pathways.
-  return [
-    [0, 1], [0, 2], [0, 5],
-    [1, 2], [1, 3], [1, 5],
-    [2, 4], [2, 5],
-    [3, 4], [3, 5], [3, 6],
-    [4, 5], [4, 7],
-    [5, 6], [5, 7], [5, 8],
-    [6, 8], [6, 9],
-    [7, 8], [7, 9],
-    [8, 9], [6, 7]
-  ];
-}
-
-function tracePolyline(ctx, points, strokeStyle, lineWidth) {
-  if (!points.length) {
-  ctx.restore();
-}
-
-function drawPolyline(ctx, points) {
-  if (!points || points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let i = 1; i < points.length; i += 1) {
-    ctx.lineTo(points[i].x, points[i].y);
-  }
-  ctx.stroke();
-}
-
-function drawCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function ensureLayerArray(layers, fallback) {
-  const base = Array.isArray(layers) ? layers.slice(0) : [];
-  for (let i = 0; i < fallback.length; i += 1) {
-    if (!base[i]) {
-      base[i] = fallback[i];
-    }
-  }
-  return base.slice(0, fallback.length);
-}
-
-function drawHelixLattice(ctx, frame, { palette, NUM }) {
-  ctx.save();
-
-  const samples = NUM.ONEFORTYFOUR;
-  const centerY = frame.y + frame.height / 2;
-  const amplitude = frame.height / (NUM.THREE + NUM.SEVEN / NUM.TWENTYTWO);
-  const angleMultiplier = Math.PI * (NUM.THREE + NUM.ELEVEN / NUM.TWENTYTWO);
-
-  const strandA = [];
-  const strandB = [];
-  for (let i = 0; i < samples; i += 1) {
-    const t = i / (samples - 1);
-    const x = frame.x + t * frame.width;
-    const angle = t * angleMultiplier;
-    strandA.push({ x, y: centerY + Math.sin(angle) * amplitude });
-    strandB.push({ x, y: centerY + Math.sin(angle + Math.PI) * amplitude });
-function paintFibonacciCurve(ctx, { width, height, palette, NUM }) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO;
-  const rotations = NUM.NINE / NUM.THREE; // Three full turns keep the spiral serene.
-  const centerX = width * (NUM.SEVEN / NUM.TWENTYTWO);
-  const centerY = height * (NUM.ELEVEN / NUM.TWENTYTWO);
-  const baseRadius = Math.min(width, height) / NUM.THIRTYTHREE;
-  const growth = NUM.ELEVEN / NUM.SEVEN;
-
-  const points = [];
-  for (let i = 0; i <= steps; i += 1) {
-    const t = i / steps;
-    const angle = rotations * Math.PI * 2 * t;
-    const radius = baseRadius * Math.pow(phi, growth * t);
-    points.push({
-      x: centerX + Math.cos(angle) * radius,
-      y: centerY + Math.sin(angle) * radius
-    });
-  }
-
-  ctx.save();
-  ctx.globalAlpha = 0.75;
-  ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = Math.max(1.5, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.THREE);
-  strokePolyline(ctx, points);
-
-  // Anchor markers provide gentle focus without motion cues.
-  ctx.globalAlpha = 0.55;
-  ctx.fillStyle = palette.layers[3];
-  const markerRadius = Math.max(3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN / NUM.ELEVEN);
-  for (let i = 1; i < points.length; i += Math.max(1, Math.floor(points.length / NUM.NINE))) {
-    const point = points[i];
-    drawCircle(ctx, point.x, point.y, markerRadius, { fill: true });
-  }
-  ctx.restore();
-}
-
-function paintHelixLattice(ctx, { width, height, palette, NUM }) {
-  const samples = NUM.ONEFORTYFOUR;
-  const verticalMargin = height / NUM.ELEVEN;
-  const usableHeight = height - verticalMargin * 2;
-  const centerX = width * (NUM.ELEVEN / NUM.TWENTYTWO);
-  const amplitude = width / NUM.NINE;
-  const turns = NUM.THREE;
-
-  const strandA = [];
-  const strandB = [];
-  for (let i = 0; i <= samples; i += 1) {
-    const t = i / samples;
-    const angle = turns * Math.PI * 2 * t;
-    const y = verticalMargin + usableHeight * t;
-    strandA.push({ x: centerX + Math.sin(angle) * amplitude, y });
-    strandB.push({ x: centerX + Math.sin(angle + Math.PI) * amplitude, y });
-  }
-  return points;
-function applyAlpha(hex, alpha) {
-  const rgb = hexToRgb(hex);
-  const safeAlpha = Math.max(0, Math.min(alpha, 1));
-  return "rgba(" + rgb.r + "," + rgb.g + "," + rgb.b + "," + safeAlpha + ")";
-}
-
-function hexToRgb(hex) {
-  if (!hex) {
-    return { r: 232, g: 232, b: 240 };
-  }
-
-  ctx.save();
-  ctx.globalAlpha = 0.8;
-  ctx.strokeStyle = strandA;
-  ctx.lineWidth = 2;
-  drawPolyline(ctx, strand1);
-  ctx.strokeStyle = strandB;
-  drawPolyline(ctx, strand2);
-
-  ctx.globalAlpha = 0.4;
-  ctx.strokeStyle = rungColor;
-  ctx.lineWidth = 1.2;
-  const rungStep = Math.max(1, Math.floor(samples / NUM.TWENTYTWO));
-  for (let i = 0; i < strand1.length; i += rungStep) {
-    const a = strand1[i];
-    const b = strand2[i];
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  const strandWidth = Math.max(1.25, frame.width / NUM.ONEFORTYFOUR * NUM.THREE / NUM.ELEVEN);
-  tracePolyline(ctx, strandA, { color: palette.layers[3], lineWidth: strandWidth, alpha: 0.7 });
-  tracePolyline(ctx, strandB, { color: palette.layers[4], lineWidth: strandWidth, alpha: 0.7 });
-
-  ctx.strokeStyle = withAlpha(palette.layers[5], 0.45);
-  ctx.lineWidth = Math.max(1, strandWidth * 0.85);
-  const rungStep = Math.max(2, Math.floor(samples / NUM.TWENTYTWO));
-  for (let i = 0; i < samples; i += rungStep) {
-    const a = strandA[i];
-    const b = strandB[i];
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
-
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-  ctx.restore();
-}
-
-function drawCircle(ctx, cx, cy, radius) {
-function drawCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  ctx.stroke();
-}
-
-function drawPolyline(ctx, points) {
-function drawCircle(ctx, cx, cy, radius, options = {}) {
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  }
-
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-  ctx.restore();
-}
-
-  ctx.strokeRect(frame.x, frame.y, frame.width, frame.height);
-  ctx.restore();
-}
-
-function drawCircle(ctx, cx, cy, radius) {
-  ctx.save();
-  ctx.globalAlpha = 0.7;
-  ctx.lineWidth = Math.max(1.3, Math.min(width, height) / NUM.ONEFORTYFOUR * NUM.SEVEN);
-  ctx.strokeStyle = palette.layers[4];
-  strokePolyline(ctx, strandA);
-  ctx.strokeStyle = palette.layers[5];
-  strokePolyline(ctx, strandB);
-
-  // Cross rungs reference 33 + 66 ratios for a static lattice rhythm.
-  const rungStep = Math.max(2, Math.floor(samples / NUM.THIRTYTHREE));
-  ctx.globalAlpha = 0.45;
-  ctx.strokeStyle = palette.layers[2];
-  for (let i = 0; i <= samples; i += rungStep) {
-    const a = strandA[i];
-    const b = strandB[i];
-    drawLine(ctx, a.x, a.y, b.x, b.y);
-  }
-  ctx.restore();
-}
-
-function drawCircle(ctx, cx, cy, radius, options) {
-  const opts = options || {};
-  ctx.beginPath();
-  ctx.arc(cx, cy, radius, 0, Math.PI * 2);
-  if (opts.fill) {
-    ctx.fill();
-  }
-  if (options.stroke) {
-  if (opts.stroke) {
-    ctx.stroke();
-  }
-}
-
-function drawPolyline(ctx, points) {
-  if (!points.length) {
-function drawLine(ctx, ax, ay, bx, by) {
-  ctx.beginPath();
-  ctx.moveTo(ax, ay);
-  ctx.lineTo(bx, by);
-  ctx.stroke();
-}
-
-function strokePolyline(ctx, points) {
-  if (!Array.isArray(points) || points.length === 0) {
-    return;
-  }
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    const point = points[index];
-    ctx.lineTo(point.x, point.y);
-  const raw = hex.replace("#", "");
-  const value = raw.length === 3
-    ? raw.split("").map(ch => ch + ch).join("")
-    : raw;
-  const intValue = parseInt(value, 16);
-  if (Number.isNaN(intValue)) {
-    return { r: 232, g: 232, b: 240 };
-  }
-  return {
-    r: (intValue >> 16) & 255,
-    g: (intValue >> 8) & 255,
-    b: intValue & 255
-  };
+  return value;
 }


### PR DESCRIPTION
## Summary
- rebuild the offline Cosmic Helix renderer HTML shell with clear ND-safe messaging and palette loading fallback
- replace the helix renderer module with pure, layered drawing helpers that render vesica lattice, Tree-of-Life, Fibonacci curve, and double helix using numerology constants
- refresh the renderer README with ASCII-safe documentation on files, layers, palette usage, and accessibility notes

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d346884c3083288cc37c19ffefeb84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline use: open the files directly in your browser (file://) with automatic palette loading and a safe fallback.
  - Unified status reporting with clear, calm messages and a visible palette notice when needed.

- Changes
  - Single, non-animated render for ND-safe viewing.
  - Fixed canvas size (1440×900), updated typography/spacing, and simplified header.
  - Improved accessibility: clearer contrast, padding, and depth cues.

- Documentation
  - Revised usage steps for offline setup.
  - Updated palette guidance and fallback behavior.
  - Overhauled layer breakdown and accessibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->