### PR TITLE
Add GitHub Pages workflow for static site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy cathedral to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency: pages
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # If you're not building, just upload the static folder:
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/cathedral
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/cathedral/index.html
+++ b/apps/cathedral/index.html
@@ -5,6 +5,16 @@
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <meta name="color-scheme" content="light dark">
+  <base id="deployment-base" href="/cathedral/">
+  <script>
+    // Keep offline-first promise: file:// loads need relative paths rather than /cathedral/.
+    if (window.location.protocol === "file:") {
+      const elBase = document.getElementById("deployment-base");
+      if (elBase) {
+        elBase.setAttribute("href", "./");
+      }
+    }
+  </script>
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }


### PR DESCRIPTION
## Summary
- add a GitHub Pages workflow that uploads the static apps/cathedral site
- insert a base tag with a file:// fallback so GitHub Pages serves assets under /cathedral/

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d34b2ef21c8328b36345771203c5d9