### PR TITLE
Add path fixer script and GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,22 @@
+name: Deploy cathedral to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/cathedral
+      - name: Deploy
+        uses: actions/deploy-pages@v4

--- a/tools/fix-relative-paths.sh
+++ b/tools/fix-relative-paths.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 0) Where your static site lives (change if needed)
+ROOT_DIR="apps/cathedral"
+export ROOT_DIR
+
+python <<'PY'
+import os
+import re
+import sys
+from pathlib import Path
+
+root = Path(os.environ["ROOT_DIR"]).resolve()
+if not root.exists():
+    sys.exit(f"Root directory {root} not found")
+
+patterns = [
+    (".html", re.compile(r"\b(src|href)\s*=\s*(['\"])\/(?!\/)"), r"\1=\2./"),
+    (".css", re.compile(r"url\(\s*(['\"]?)\/(?!\/)"), r"url(\1./"),
+    (".js", re.compile(r"\b(fetch|Request|import)\(\s*(['\"])\/(?!\/)"), r"\1(\2./"),
+]
+
+for suffix, regex, repl in patterns:
+    for path in root.rglob(f"*{suffix}"):
+        if not path.is_file():
+            continue
+        original = path.read_text(encoding="utf-8")
+        updated = regex.sub(repl, original)
+        if updated != original:
+            backup = path.with_suffix(path.suffix + ".bak")
+            backup.write_text(original, encoding="utf-8")
+            path.write_text(updated, encoding="utf-8")
+
+print(f"✅ Rewrote absolute paths under {root}")
+print("   Backups created as *.bak next to each file.")
+print("   To review changes: git diff")
+PY


### PR DESCRIPTION
## Summary
- add a helper script that rewrites leading-slash asset references within the apps/cathedral static site
- configure a GitHub Pages workflow that uploads the apps/cathedral folder

## Testing
- tools/fix-relative-paths.sh

------
https://chatgpt.com/codex/tasks/task_e_68d34d30d05483288c7193cee0a9f342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enabled automated deployment of the site to GitHub Pages on push to main and via manual trigger.
- Bug Fixes
  - Fixed asset and link paths in static files by converting absolute URLs to relative ones, ensuring images, styles, and scripts load correctly on GitHub Pages.
- Chores
  - Added CI improvements for reliable site publishing and a tooling script to batch-rewrite paths with backups for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->