### PR TITLE
Refine cosmic helix offline renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,64 +4,40 @@
   <meta charset="utf-8">
   <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
-
-  <meta name="color-scheme" content="dark light">
-  <style>
-    /* ND-safe styling: calm contrast, no motion, spacious layout */
-
   <meta name="color-scheme" content="light dark">
   <style>
-    /* ND-safe styling: calm contrast, zero motion, generous whitespace */
-
+    /* ND-safe styling: calm contrast, no motion, clear typographic rhythm */
     :root {
       --bg: #0b0b12;
       --ink: #e8e8f0;
-      --muted: #9ea2c9;
+      --muted: #a6a6c1;
     }
-
-    html, body {
 
     html,
     body {
-
       margin: 0;
       padding: 0;
       background: var(--bg);
       color: var(--ink);
-
-      font: 14px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-    }
-
-    header {
-      padding: 16px 20px;
-      border-bottom: 1px solid #1d1d2a;
-      box-shadow: 0 1px 0 rgba(12, 12, 20, 0.6);
-
       font: 14px/1.5 system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     }
 
     header {
       padding: 14px 18px;
       border-bottom: 1px solid #1d1d2a;
-
+      box-shadow: 0 1px 0 rgba(12, 12, 20, 0.65);
       letter-spacing: 0.02em;
     }
 
-    h1 {
-      margin: 0;
+    header strong {
       font-size: 20px;
+      font-weight: 600;
     }
 
     .status {
-
-      color: var(--muted);
-      font-size: 12px;
-      margin-top: 4px;
-
       margin-top: 4px;
       color: var(--muted);
       font-size: 12px;
-
     }
 
     #stage {
@@ -69,26 +45,16 @@
       width: 1440px;
       height: 900px;
       margin: 18px auto 12px;
-
       box-shadow: 0 0 0 1px #1d1d2a, 0 16px 34px rgba(0, 0, 0, 0.28);
-
-      box-shadow: 0 0 0 1px #1d1d2a, 0 14px 32px rgba(0, 0, 0, 0.32);
-
       background: var(--bg);
     }
 
     .note {
       max-width: 900px;
       margin: 0 auto 24px;
-
       padding: 0 18px;
       color: var(--muted);
       text-align: center;
-
-      padding: 0 16px;
-      text-align: center;
-      color: var(--muted);
-
     }
 
     code {
@@ -100,9 +66,8 @@
 </head>
 <body>
   <header>
-    <h1>Cosmic Helix Renderer</h1>
-
-    <p class="status" id="status">Preparing static layers…</p>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Preparing static layers...</div>
   </header>
 
   <canvas
@@ -111,15 +76,10 @@
     height="900"
     aria-label="Layered sacred geometry canvas"
   ></canvas>
-  <p class="note">Offline renderer for the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. Open this file directly; no network or animation occurs.</p>
-
-    <div class="status" id="status">Loading palette…</div>
-  </header>
-
-  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">Static layered cosmology: Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice. No
-    animation, no external libraries, safe to open offline.</p>
-
+  <p class="note">
+    Offline renderer for the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
+    Open this file directly; no network calls or animation occur.
+  </p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -128,31 +88,12 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-
+    // ND-safe fallback colors in case the JSON file is absent or blocked.
     const FALLBACK_PALETTE = Object.freeze({
       bg: "#0b0b12",
       ink: "#e8e8f0",
-      layers: ["#88a6ff", "#7fe7f2", "#9cf5b4", "#ffd27f", "#f4a7ff", "#d6d6ed"]
-    });
-=======
-    async function loadJSON(path) {
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          return null;
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    const FALLBACK_PALETTE = {
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
       layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    };
-
+    });
 
     const NUMEROLOGY = Object.freeze({
       THREE: 3,
@@ -165,17 +106,18 @@
       ONEFORTYFOUR: 144
     });
 
-
-    function report(message) {
+    function updateStatus(message) {
       statusEl.textContent = message;
     }
 
+    // Try to load the palette locally without touching the network.
     async function loadPalette() {
-      const path = "./data/palette.json";
+      const localPath = "./data/palette.json";
 
       if (window.location.protocol === "file:") {
         try {
-          const module = await import(path, { assert: { type: "json" } });
+          // JSON modules work for modern browsers when opened via file://.
+          const module = await import(localPath, { assert: { type: "json" } });
           return module.default;
         } catch (error) {
           return null;
@@ -183,9 +125,9 @@
       }
 
       try {
-        const response = await fetch(path, { cache: "no-store" });
+        const response = await fetch(localPath, { cache: "no-store" });
         if (!response.ok) {
-          throw new Error(String(response.status));
+          return null;
         }
         return await response.json();
       } catch (error) {
@@ -195,7 +137,7 @@
 
     async function init() {
       if (!ctx) {
-        report("Canvas context unavailable; rendering skipped to stay ND-safe.");
+        updateStatus("Canvas context unavailable; rendering skipped to stay ND-safe.");
         return;
       }
 
@@ -203,46 +145,27 @@
       const palette = paletteData || FALLBACK_PALETTE;
       const missingPalette = !paletteData;
 
-      report(missingPalette ? "Palette missing or blocked; using ND-safe fallback." : "Palette loaded; rendering calm layers.");
+      updateStatus(
+        missingPalette
+          ? "Palette missing or unreadable; using safe fallback."
+          : "Palette loaded from data/palette.json."
+      );
 
-      try {
-        const result = renderHelix(ctx, {
-          width: canvas.width,
-          height: canvas.height,
-          palette,
-          NUM,
-          missingPalette
-        });
+      // Render once with explicit numerology constants for determinism.
+      const result = renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette,
+        numerology: NUMEROLOGY,
+        missingPalette
+      });
 
-        if (result && result.ok) {
-          report(missingPalette ? "Rendered with fallback palette. Layers remain static." : "Rendered with custom palette. Layers remain static.");
-        } else {
-          report("Render skipped; see console for diagnostics.");
-        }
-      } catch (error) {
-        console.error(error);
-        report("Renderer failed; see console for details.");
+      if (!result || !result.ok) {
+        updateStatus("Renderer declined to draw; see console for diagnostics.");
       }
     }
 
     init();
-
-    const paletteData = await loadJSON("./data/palette.json");
-    const paletteMissing = !paletteData;
-    const palette = paletteMissing ? FALLBACK_PALETTE : paletteData;
-
-    statusEl.textContent = paletteMissing
-      ? "Palette missing or unreadable; using safe fallback."
-      : "Palette loaded from data/palette.json.";
-
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette,
-      numerology: NUMEROLOGY,
-      missingPalette: paletteMissing
-    });
-
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,37 +1,24 @@
 /*
   helix-renderer.mjs
 
-  Static, offline renderer for the layered Cosmic Helix cosmology.
+  ND-safe static renderer for the layered Cosmic Helix cosmology.
+  Geometry renders once per invocation and never animates, ensuring
+  sensory calm while keeping sacred depth intact.
 
-  Layer sequence (renders from base to crown):
-    1. Vesica field (intersecting lattice) for grounding geometry.
-    2. Tree-of-Life scaffold (10 nodes, 22 paths) for structure.
-    3. Fibonacci curve (phi spiral approximation) for growth.
-    4. Double-helix lattice (mirrored strands) for crown resonance.
+  Layer sequence (base to crown):
+    1) Vesica field - interlocking circles for grounding geometry.
+    2) Tree-of-Life scaffold - ten sephirot with twenty-two connective paths.
+    3) Fibonacci curve - phi-guided growth arc plotted as a static polyline.
+    4) Double-helix lattice - mirrored strands with gentle crossbars.
 
-  ND-safe principles: no animation loops, calm contrast, generous clearspace.
-  All helpers are pure and side-effect free beyond drawing into the provided context.
-
-  Static, ND-safe renderer for the Cosmic Helix canvas.
-
-  Layer order preserves sensory calm and sacred depth:
-    1) Vesica field (interlocking circles as the grounding lattice)
-    2) Tree-of-Life scaffold (ten sephirot, twenty-two connective paths)
-    3) Fibonacci curve (phi-guided spiral drawn once, no motion)
-    4) Double helix lattice (two mirrored strands with steady crossbars)
-
-  All helpers are pure and deterministic so offline edits stay predictable.
-
+  All drawing helpers are pure functions that receive explicit state
+  so the renderer stays predictable when edited offline.
 */
 
 const DEFAULT_PALETTE = Object.freeze({
   bg: "#0b0b12",
   ink: "#e8e8f0",
-
-  layers: ["#88a6ff", "#7fe7f2", "#9cf5b4", "#ffd27f", "#f4a7ff", "#d6d6ed"]
-
   layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-
 });
 
 const DEFAULT_NUMEROLOGY = Object.freeze({
@@ -44,7 +31,6 @@ const DEFAULT_NUMEROLOGY = Object.freeze({
   NINETYNINE: 99,
   ONEFORTYFOUR: 144
 });
-
 
 const TREE_PATHS = Object.freeze([
   ["keter", "chokmah"],
@@ -71,35 +57,35 @@ const TREE_PATHS = Object.freeze([
   ["binah", "hod"]
 ]);
 
+const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
+const TAU = Math.PI * 2;
+
 export function renderHelix(ctx, options = {}) {
   if (!ctx) {
     return { ok: false, reason: "missing-context" };
   }
 
-  const width = sanitiseDimension(options.width, ctx.canvas && ctx.canvas.width ? ctx.canvas.width : 1440);
-  const height = sanitiseDimension(options.height, ctx.canvas && ctx.canvas.height ? ctx.canvas.height : 900);
+  const width = sanitiseDimension(options.width, ctx.canvas ? ctx.canvas.width : 1440);
+  const height = sanitiseDimension(options.height, ctx.canvas ? ctx.canvas.height : 900);
   const palette = normalisePalette(options.palette);
-  const NUM = normaliseNumerology(options.NUM);
+  const numerology = normaliseNumerology(options.numerology || options.NUM);
+  const margin = computeMargin(width, height, numerology);
+  const stage = createStage(width, height, margin);
 
-  const minDimension = Math.min(width, height);
-  const clearCandidate = minDimension / NUM.ELEVEN;
-  const clearMinimum = (minDimension / NUM.ONEFORTYFOUR) * NUM.THREE;
-  const clearspace = Math.max(clearCandidate, clearMinimum);
-  const frame = createFrame(width, height, clearspace);
-
-const CLEARSPACE_MIN_RATIO = 0.08;
-const CLEARSPACE_MIN_PX = 48;
-const GOLDEN_RATIO = (1 + Math.sqrt(5)) / 2;
-
-export function renderHelix(ctx, options = {}) {
-  if (!ctx) {
-    return { ok: false, reason: "No 2d context provided." };
-  }
-
-  const settings = createSettings(ctx, options);
+  const settings = {
+    width,
+    height,
+    palette,
+    numerology,
+    margin,
+    stage,
+    center: { x: stage.x + stage.width / 2, y: stage.y + stage.height / 2 },
+    missingPalette: Boolean(options.missingPalette)
+  };
 
   ctx.save();
-  resetCanvas(ctx, settings);
+  configureContext(ctx);
+  paintBackground(ctx, palette.bg, width, height);
 
   drawVesicaField(ctx, settings);
   drawTreeOfLife(ctx, settings);
@@ -111,594 +97,187 @@ export function renderHelix(ctx, options = {}) {
   }
 
   ctx.restore();
-
   return { ok: true, settings };
-}
-
-function createSettings(ctx, options) {
-  const width = sanitiseDimension(options.width, ctx.canvas ? ctx.canvas.width : 1440);
-  const height = sanitiseDimension(options.height, ctx.canvas ? ctx.canvas.height : 900);
-  const palette = normalisePalette(options.palette);
-  const numerology = normaliseNumerology(options.numerology || options.NUM);
-  const margin = Math.max(CLEARSPACE_MIN_PX, Math.min(width, height) * CLEARSPACE_MIN_RATIO);
-  const stage = {
-    x: margin,
-    y: margin,
-    width: Math.max(1, width - margin * 2),
-    height: Math.max(1, height - margin * 2)
-  };
-
-  return {
-    width,
-    height,
-    palette,
-    numerology,
-    margin,
-    stage,
-    center: { x: width / 2, y: height / 2 },
-    missingPalette: Boolean(options.missingPalette)
-  };
-}
-
-
-  ctx.save();
-  configureContext(ctx);
-  paintBackground(ctx, width, height, palette.bg);
-
-
-  if (options.missingPalette) {
-    drawPaletteNotice(ctx, frame, palette, NUM);
-  }
-
-  paintVesicaField(ctx, frame, palette, NUM);
-  paintTreeOfLife(ctx, frame, palette, NUM);
-  paintFibonacciCurve(ctx, frame, palette, NUM);
-  paintHelixLattice(ctx, frame, palette, NUM);
-
-  ctx.restore();
-
-  return { ok: true, palette, NUM, frame, clearspace };
 }
 
 function configureContext(ctx) {
   ctx.lineCap = "round";
   ctx.lineJoin = "round";
+  ctx.miterLimit = 6;
 }
 
-function paintBackground(ctx, width, height, color) {
+function paintBackground(ctx, color, width, height) {
   ctx.clearRect(0, 0, width, height);
   ctx.fillStyle = color;
   ctx.fillRect(0, 0, width, height);
 }
 
-function drawPaletteNotice(ctx, frame, palette, NUM) {
-  const message = "Palette fallback active (data/palette.json missing).";
-  const padding = frame.clearspace / NUM.ONEFORTYFOUR * NUM.SEVEN;
-  const textY = frame.y + Math.max(4, frame.clearspace / NUM.ELEVEN);
-
-  ctx.save();
-  ctx.font = "14px system-ui, sans-serif";
-  ctx.textBaseline = "top";
-  const metrics = ctx.measureText(message);
-  const textWidth = metrics.width;
-  const textHeight = 18;
-
-  ctx.fillStyle = withAlpha(palette.bg, 0.85);
-  ctx.fillRect(frame.x - padding, textY - padding, textWidth + padding * 2, textHeight + padding);
-
-  ctx.fillStyle = withAlpha(palette.ink, 0.7);
-  ctx.fillText(message, frame.x, textY);
-  ctx.restore();
-}
-
-function paintVesicaField(ctx, frame, palette, NUM) {
-  const rows = NUM.SEVEN;
-  const cols = NUM.NINE;
-  const stepX = frame.width / (cols - 1);
-  const stepY = frame.height / (rows - 1);
-  const radius = Math.min(stepX, stepY) * NUM.NINE / NUM.TWENTYTWO;
-  const offset = radius / NUM.THREE;
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.45);
-  ctx.lineWidth = Math.max(1, radius / NUM.ELEVEN);
-
-function normalisePalette(input) {
-  if (!input) {
-    return DEFAULT_PALETTE;
-  }
-
-  const layers = Array.isArray(input.layers)
-    ? input.layers.filter(color => typeof color === "string" && color.trim())
-    : [];
-
-  while (layers.length < DEFAULT_PALETTE.layers.length) {
-    layers.push(DEFAULT_PALETTE.layers[layers.length]);
-  }
-
-  return {
-    bg: typeof input.bg === "string" ? input.bg : DEFAULT_PALETTE.bg,
-    ink: typeof input.ink === "string" ? input.ink : DEFAULT_PALETTE.ink,
-    layers: layers.slice(0, DEFAULT_PALETTE.layers.length)
-  };
-}
-
-function normaliseNumerology(input) {
-  if (!input) {
-    return DEFAULT_NUMEROLOGY;
-  }
-
-  const output = { ...DEFAULT_NUMEROLOGY };
-  for (const key of Object.keys(DEFAULT_NUMEROLOGY)) {
-    const value = input[key];
-    if (Number.isFinite(value) && value > 0) {
-      output[key] = value;
-    }
-  }
-  return output;
-}
-
-function resetCanvas(ctx, settings) {
-  ctx.setTransform(1, 0, 0, 1, 0, 0);
-  ctx.clearRect(0, 0, settings.width, settings.height);
-  ctx.fillStyle = settings.palette.bg;
-  ctx.fillRect(0, 0, settings.width, settings.height);
-}
-
 function drawVesicaField(ctx, settings) {
   const { stage, palette, numerology } = settings;
-  const cols = Math.max(2, Math.floor(numerology.NINE));
-  const rows = Math.max(2, Math.floor(numerology.SEVEN));
-  const field = insetRect(stage, 0.92);
-  const spacingX = cols > 1 ? field.width / (cols - 1) : field.width;
-  const spacingY = rows > 1 ? field.height / (rows - 1) : field.height;
-  const radius = Math.min(spacingX, spacingY) / 2.2;
+  const rows = numerology.SEVEN;
+  const cols = numerology.NINE;
+  const stepX = stage.width / (cols - 1);
+  const stepY = stage.height / (rows - 1);
+  const radius = Math.min(stepX, stepY) * numerology.NINE / numerology.TWENTYTWO;
+  const strokeWidth = Math.max(1.5, radius / numerology.THIRTYTHREE);
+  const color = withAlpha(palette.layers[0], 0.22);
 
   ctx.save();
-  ctx.strokeStyle = palette.layers[0];
-  ctx.lineWidth = Math.max(1, stage.width / 720);
-  ctx.globalAlpha = 0.88;
+  ctx.lineWidth = strokeWidth;
+  ctx.strokeStyle = color;
 
   for (let row = 0; row < rows; row += 1) {
-    const y = field.y + row * spacingY;
     for (let col = 0; col < cols; col += 1) {
-
-      const cx = frame.x + col * stepX;
-      const cy = frame.y + row * stepY;
-      drawCircle(ctx, cx - offset, cy, radius, { stroke: true, fill: false });
-      drawCircle(ctx, cx + offset, cy, radius, { stroke: true, fill: false });
-
-      const x = field.x + col * spacingX;
-      strokeCircle(ctx, x, y, radius);
-      // Offset circle to create vesica overlap using numerology.THREE as divisor.
-      const offset = spacingX / numerology.THREE;
-      strokeCircle(ctx, x + offset / 2, y, radius);
-
+      const cx = stage.x + col * stepX;
+      const cy = stage.y + row * stepY;
+      ctx.beginPath();
+      ctx.arc(cx, cy, radius, 0, TAU);
+      ctx.stroke();
     }
   }
 
   ctx.restore();
-
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[0], 0.2);
-  ctx.lineWidth = Math.max(1, radius / NUM.NINETYNINE * NUM.SEVEN);
-  const centerX = frame.x + frame.width / 2;
-  const centerY = frame.y + frame.height / 2;
-  const ringCount = NUM.SEVEN;
-  for (let index = 1; index <= ringCount; index += 1) {
-    const ringRadius = radius * (1 + index / (NUM.SEVEN + NUM.THREE));
-    drawCircle(ctx, centerX, centerY, ringRadius, { stroke: true, fill: false });
-  }
-
-  const gridSteps = NUM.NINE;
-  for (let i = 0; i <= gridSteps; i += 1) {
-    const x = frame.x + (frame.width / gridSteps) * i;
-    const y = frame.y + (frame.height / gridSteps) * i;
-    drawLine(ctx, x, frame.y, x, frame.y + frame.height);
-    drawLine(ctx, frame.x, y, frame.x + frame.width, y);
-  }
-  ctx.restore();
-}
-
-function paintTreeOfLife(ctx, frame, palette, NUM) {
-  const nodes = buildTreeNodes(frame, NUM);
-  const nodeRadius = Math.min(frame.width, frame.height) / NUM.THIRTYTHREE;
-  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[1], 0.6);
-  ctx.lineWidth = Math.max(1.2, nodeRadius / NUM.ELEVEN);
-  TREE_PATHS.forEach(([fromId, toId]) => {
-    const from = nodeMap.get(fromId);
-    const to = nodeMap.get(toId);
-    if (from && to) {
-      drawLine(ctx, from.x, from.y, to.x, to.y);
-    }
-  });
-  ctx.restore();
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.ink, 0.72);
-  ctx.fillStyle = withAlpha(palette.layers[2], 0.85);
-  ctx.lineWidth = Math.max(1, nodeRadius / NUM.THIRTYTHREE * NUM.SEVEN);
-  nodes.forEach((node) => {
-    drawCircle(ctx, node.x, node.y, nodeRadius, { stroke: true, fill: true });
-  });
-  ctx.restore();
-}
-
-function paintFibonacciCurve(ctx, frame, palette, NUM) {
-  const phi = (1 + Math.sqrt(5)) / 2;
-  const steps = NUM.TWENTYTWO + NUM.ELEVEN;
-  const angleRange = Math.PI * (NUM.THIRTYTHREE / NUM.ELEVEN);
-  const originX = frame.x + frame.width / NUM.THREE;
-  const originY = frame.y + frame.height * (NUM.TWENTYTWO / NUM.THIRTYTHREE);
-  const scale = Math.min(frame.width, frame.height) / NUM.TWENTYTWO;
-
-  const points = [];
-  for (let index = 0; index <= steps; index += 1) {
-    const ratio = index / steps;
-    const angle = angleRange * ratio;
-    const radius = scale * Math.pow(phi, ratio * (NUM.THIRTYTHREE / NUM.NINETYNINE));
-    const x = originX + radius * Math.cos(angle);
-    const y = originY - radius * Math.sin(angle);
-    points.push({ x, y });
-  }
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[3], 0.82);
-  ctx.lineWidth = Math.max(1.5, scale / NUM.ELEVEN);
-  drawPolyline(ctx, points);
-  ctx.restore();
-
-  if (points.length > 1) {
-    ctx.save();
-    ctx.fillStyle = withAlpha(palette.layers[3], 0.9);
-    const markerRadius = Math.max(2, scale / NUM.THIRTYTHREE);
-    drawCircle(ctx, points[0].x, points[0].y, markerRadius, { stroke: false, fill: true });
-    const last = points[points.length - 1];
-    drawCircle(ctx, last.x, last.y, markerRadius, { stroke: false, fill: true });
-    ctx.restore();
-  }
-}
-
-function paintHelixLattice(ctx, frame, palette, NUM) {
-  const samples = NUM.NINETYNINE;
-  const centerX = frame.x + frame.width / 2;
-  const amplitude = frame.width / NUM.TWENTYTWO;
-  const frequency = Math.PI * (NUM.THIRTYTHREE / NUM.ELEVEN);
-  const pointsA = [];
-  const pointsB = [];
-
-  for (let index = 0; index < samples; index += 1) {
-    const t = index / (samples - 1);
-    const angle = frequency * t;
-    const y = frame.y + t * frame.height;
-    const xA = centerX + amplitude * Math.sin(angle);
-    const xB = centerX - amplitude * Math.sin(angle);
-    pointsA.push({ x: xA, y });
-    pointsB.push({ x: xB, y });
-  }
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[4], 0.7);
-  ctx.lineWidth = Math.max(1, amplitude / NUM.THIRTYTHREE);
-  drawPolyline(ctx, pointsA);
-  drawPolyline(ctx, pointsB);
-  ctx.restore();
-
-  const rungStep = Math.max(1, Math.round(samples / NUM.TWENTYTWO));
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[5], 0.45);
-  ctx.lineWidth = Math.max(1, amplitude / NUM.NINETYNINE * NUM.SEVEN);
-  for (let i = 0; i < samples; i += rungStep) {
-    const start = pointsA[i];
-    const end = pointsB[i];
-    if (start && end) {
-      drawLine(ctx, start.x, start.y, end.x, end.y);
-    }
-  }
-  ctx.restore();
-
-  ctx.save();
-  ctx.strokeStyle = withAlpha(palette.layers[5], 0.22);
-  ctx.lineWidth = Math.max(1, amplitude / NUM.ONEFORTYFOUR * NUM.SEVEN);
-  drawLine(ctx, centerX, frame.y, centerX, frame.y + frame.height);
-  ctx.restore();
-
-  const beadStep = Math.max(1, Math.round(samples / NUM.THIRTYTHREE));
-  ctx.save();
-  ctx.fillStyle = withAlpha(palette.layers[4], 0.82);
-  const beadRadius = Math.max(1.5, amplitude / NUM.ONEFORTYFOUR * NUM.SEVEN);
-  for (let i = 0; i < samples; i += beadStep) {
-    const a = pointsA[i];
-    const b = pointsB[i];
-    if (a && b) {
-      drawCircle(ctx, a.x, a.y, beadRadius, { stroke: false, fill: true });
-      drawCircle(ctx, b.x, b.y, beadRadius, { stroke: false, fill: true });
-    }
-  }
-  ctx.restore();
-}
-
-function buildTreeNodes(frame, NUM) {
-  const centerX = frame.x + frame.width / 2;
-  const offsetMajor = frame.width * NUM.SEVEN / NUM.THIRTYTHREE;
-  const offsetMinor = frame.width * NUM.THREE / NUM.THIRTYTHREE;
-  const tierSpacing = frame.height / (NUM.SEVEN + NUM.THREE);
-
-  const yKeter = frame.y + tierSpacing;
-  const ySupernal = yKeter + tierSpacing;
-  const yChesed = ySupernal + tierSpacing * (NUM.TWENTYTWO / NUM.ELEVEN);
-  const yTiferet = yChesed + tierSpacing;
-  const yNetzach = yTiferet + tierSpacing * (NUM.TWENTYTWO / NUM.ELEVEN);
-  const yYesod = yNetzach + tierSpacing;
-  const yMalkuth = yYesod + tierSpacing;
-
-  return [
-    { id: "keter", x: centerX, y: yKeter },
-    { id: "chokmah", x: centerX + offsetMajor, y: ySupernal },
-    { id: "binah", x: centerX - offsetMajor, y: ySupernal },
-    { id: "chesed", x: centerX + offsetMinor, y: yChesed },
-    { id: "gevurah", x: centerX - offsetMinor, y: yChesed },
-    { id: "tiferet", x: centerX, y: yTiferet },
-    { id: "netzach", x: centerX + offsetMinor, y: yNetzach },
-    { id: "hod", x: centerX - offsetMinor, y: yNetzach },
-    { id: "yesod", x: centerX, y: yYesod },
-    { id: "malkuth", x: centerX, y: yMalkuth }
-  ];
-}
-
-function drawCircle(ctx, x, y, radius, mode) {
-=======
 }
 
 function drawTreeOfLife(ctx, settings) {
   const { stage, palette, numerology } = settings;
-  const nodes = computeTreeNodes(stage);
-  const paths = computeTreePaths();
-  const nodeRadius = Math.max(6, Math.min(stage.width, stage.height) / (numerology.TWENTYTWO));
-  const pathWidth = Math.max(1.5, stage.width / (numerology.NINETYNINE));
+  const nodes = createTreeNodes(stage, numerology);
+  const pathColor = withAlpha(palette.layers[1], 0.65);
+  const nodeColor = palette.layers[2];
+  const haloColor = withAlpha(palette.layers[2], 0.2);
+  const pathWidth = Math.max(2, stage.width / numerology.ONEFORTYFOUR * numerology.THREE / numerology.SEVEN);
+  const nodeRadius = Math.max(stage.width, stage.height) / numerology.NINETYNINE;
+  const haloRadius = nodeRadius * (numerology.TWENTYTWO / numerology.ELEVEN);
 
   ctx.save();
   ctx.lineWidth = pathWidth;
-  ctx.strokeStyle = palette.layers[1];
-  ctx.globalAlpha = 0.9;
+  ctx.strokeStyle = pathColor;
 
-  for (const [fromIndex, toIndex] of paths) {
-    const from = nodes[fromIndex];
-    const to = nodes[toIndex];
+  for (const [a, b] of TREE_PATHS) {
+    const start = nodes[a];
+    const end = nodes[b];
+    if (!start || !end) {
+      continue;
+    }
     ctx.beginPath();
-    ctx.moveTo(from.x, from.y);
-    ctx.lineTo(to.x, to.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
 
-  ctx.fillStyle = palette.layers[2];
-  ctx.strokeStyle = palette.ink;
-  ctx.lineWidth = Math.max(1, pathWidth / 2);
-
-  for (const node of nodes) {
+  for (const key of Object.keys(nodes)) {
+    const node = nodes[key];
     ctx.beginPath();
-    ctx.arc(node.x, node.y, nodeRadius, 0, Math.PI * 2);
+    ctx.fillStyle = haloColor;
+    ctx.arc(node.x, node.y, haloRadius, 0, TAU);
     ctx.fill();
-    ctx.stroke();
+
+    ctx.beginPath();
+    ctx.fillStyle = nodeColor;
+    ctx.arc(node.x, node.y, nodeRadius, 0, TAU);
+    ctx.fill();
   }
 
   ctx.restore();
 }
 
-function computeTreeNodes(stage) {
-  const layout = [
-    { x: 0.5, y: 0.04 }, // Keter
-    { x: 0.78, y: 0.16 }, // Chokmah
-    { x: 0.22, y: 0.16 }, // Binah
-    { x: 0.8, y: 0.34 }, // Chesed
-    { x: 0.2, y: 0.34 }, // Gevurah
-    { x: 0.5, y: 0.48 }, // Tiferet
-    { x: 0.82, y: 0.64 }, // Netzach
-    { x: 0.18, y: 0.64 }, // Hod
-    { x: 0.5, y: 0.78 }, // Yesod
-    { x: 0.5, y: 0.92 }  // Malkuth
-  ];
+function createTreeNodes(stage, numerology) {
+  const rowCount = numerology.SEVEN;
+  const verticalMargin = stage.height / numerology.THIRTYTHREE;
+  const usableHeight = stage.height - verticalMargin * 2;
+  const rowStep = usableHeight / (rowCount - 1);
 
-  return layout.map(point => ({
-    x: stage.x + point.x * stage.width,
-    y: stage.y + point.y * stage.height
-  }));
-}
+  const rowY = (index) => stage.y + verticalMargin + rowStep * index;
+  const centerX = stage.x + stage.width / 2;
+  const majorOffset = stage.width / numerology.THREE;
+  const minorOffset = stage.width / numerology.SEVEN;
 
-function computeTreePaths() {
-  return [
-    [0, 1], [0, 2], [1, 2],
-    [1, 3], [1, 5], [2, 4], [2, 5],
-    [3, 4], [3, 5], [4, 5],
-    [3, 6], [3, 8], [4, 7], [4, 8],
-    [5, 6], [5, 7], [6, 7],
-    [6, 8], [7, 8], [6, 9], [7, 9], [8, 9]
-  ];
+  return {
+    keter: { x: centerX, y: rowY(0) },
+    chokmah: { x: centerX + majorOffset, y: rowY(1) },
+    binah: { x: centerX - majorOffset, y: rowY(1) },
+    chesed: { x: centerX + minorOffset, y: rowY(2) },
+    gevurah: { x: centerX - minorOffset, y: rowY(2) },
+    tiferet: { x: centerX, y: rowY(3) },
+    netzach: { x: centerX + minorOffset, y: rowY(4) },
+    hod: { x: centerX - minorOffset, y: rowY(4) },
+    yesod: { x: centerX, y: rowY(5) },
+    malkuth: { x: centerX, y: rowY(6) }
+  };
 }
 
 function drawFibonacciCurve(ctx, settings) {
-  const { stage, palette, numerology, center } = settings;
-  const steps = Math.max(12, Math.floor(numerology.NINETYNINE));
-  const angleIncrement = Math.PI / numerology.ELEVEN;
-  const maxRadius = Math.min(stage.width, stage.height) * 0.46;
-  const baseRadius = maxRadius / numerology.THREE;
-  const spiralCenter = {
-    x: center.x,
-    y: stage.y + stage.height * 0.6
-  };
+  const { stage, palette, numerology } = settings;
+  const steps = numerology.NINETYNINE;
+  const baseRadius = Math.min(stage.width, stage.height) / numerology.THIRTYTHREE;
+  const centerX = stage.x + stage.width / numerology.THREE;
+  const centerY = stage.y + stage.height * (numerology.SEVEN / numerology.NINE);
+  const strokeWidth = Math.max(2, baseRadius / numerology.SEVEN);
+  const strokeColor = withAlpha(palette.layers[3], 0.8);
 
   const points = [];
   for (let index = 0; index < steps; index += 1) {
-    const angle = index * angleIncrement;
-    const growth = Math.pow(GOLDEN_RATIO, angle / Math.PI);
-    const radius = Math.min(maxRadius, baseRadius * growth);
-    const x = spiralCenter.x + Math.cos(angle) * radius;
-    const y = spiralCenter.y + Math.sin(angle) * radius;
-    points.push({ x, y });
-  }
-
-  if (points.length < 2) {
-    return;
+    const t = index / numerology.THIRTYTHREE;
+    const angle = t * TAU;
+    const growth = Math.pow(GOLDEN_RATIO, index / numerology.TWENTYTWO);
+    const radius = baseRadius * growth;
+    const rawX = centerX + Math.cos(angle) * radius;
+    const rawY = centerY - Math.sin(angle) * radius;
+    points.push({
+      x: clamp(rawX, stage.x, stage.x + stage.width),
+      y: clamp(rawY, stage.y, stage.y + stage.height)
+    });
   }
 
   ctx.save();
-  ctx.strokeStyle = palette.layers[3];
-  ctx.lineWidth = Math.max(1, stage.width / 960);
-
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  if (mode && mode.fill) {
-    ctx.fill();
-  }
-  if (!mode || mode.stroke) {
-    ctx.stroke();
-  }
-
-
-function drawLine(ctx, x1, y1, x2, y2) {
-  ctx.beginPath();
-  ctx.moveTo(x1, y1);
-  ctx.lineTo(x2, y2);
-  ctx.stroke();
-}
-
-function drawPolyline(ctx, points) {
-  if (!Array.isArray(points) || points.length < 2) {
-    return;
-  }
-  ctx.beginPath();
-  ctx.moveTo(points[0].x, points[0].y);
-  for (let index = 1; index < points.length; index += 1) {
-    ctx.lineTo(points[index].x, points[index].y);
-  }
-  ctx.stroke();
-}
-
-function sanitiseDimension(value, fallback) {
-  if (Number.isFinite(value) && value > 0) {
-    return value;
-  }
-  if (Number.isFinite(fallback) && fallback > 0) {
-    return fallback;
-  }
-  return 1;
-}
-
-function createFrame(width, height, clearspace) {
-  const safeClear = Math.min(clearspace, Math.min(width, height) / 2);
-  return {
-    x: safeClear,
-    y: safeClear,
-    width: width - safeClear * 2,
-    height: height - safeClear * 2,
-    clearspace: safeClear
-  };
-}
-
-function normalisePalette(candidate) {
-  if (!candidate) {
-    return DEFAULT_PALETTE;
-  }
-
-  const bg = typeof candidate.bg === "string" ? candidate.bg : DEFAULT_PALETTE.bg;
-  const ink = typeof candidate.ink === "string" ? candidate.ink : DEFAULT_PALETTE.ink;
-  const layersInput = Array.isArray(candidate.layers) ? candidate.layers : [];
-  const layers = DEFAULT_PALETTE.layers.map((color, index) => {
-    const candidateColor = layersInput[index];
-    return typeof candidateColor === "string" ? candidateColor : color;
-  });
-
-  return { bg, ink, layers };
-}
-
-function normaliseNumerology(source = {}) {
-  const numerology = {};
-  Object.keys(DEFAULT_NUM).forEach((key) => {
-    const value = source[key];
-    numerology[key] = Number.isFinite(value) && value > 0 ? value : DEFAULT_NUM[key];
-  });
-  return numerology;
-}
-
-function withAlpha(color, alpha) {
-  const { r, g, b } = parseHexColor(color || "#000000");
-  return `rgba(${r}, ${g}, ${b}, ${clampAlpha(alpha)})`;
-}
-
-function parseHexColor(value) {
-  if (typeof value !== "string") {
-    return { r: 0, g: 0, b: 0 };
-  }
-  const match = value.trim().match(/^#?([0-9a-fA-F]{6})$/);
-  if (!match) {
-    return { r: 0, g: 0, b: 0 };
-  }
-  const hex = match[1];
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return { r, g, b };
-}
-
-function clampAlpha(value) {
-  if (!Number.isFinite(value)) {
-    return 1;
-  }
-  if (value < 0) {
-    return 0;
-  }
-  if (value > 1) {
-    return 1;
-  }
-  return value;
-=======
-  ctx.stroke();
+  ctx.lineWidth = strokeWidth;
+  ctx.strokeStyle = strokeColor;
+  strokePolyline(ctx, points);
   ctx.restore();
 }
 
 function drawHelixLattice(ctx, settings) {
   const { stage, palette, numerology } = settings;
-  const samples = Math.max(12, Math.floor(numerology.ONEFORTYFOUR));
-  const amplitude = stage.width / numerology.SEVEN;
-  const verticalStep = stage.height / (samples - 1);
-  const frequency = (Math.PI * 2) / numerology.THIRTYTHREE;
-
+  const sampleCount = numerology.NINETYNINE;
+  const amplitude = stage.width / numerology.NINE;
+  const spineX = stage.x + stage.width * (numerology.ELEVEN / numerology.TWENTYTWO);
+  const phaseOffset = stage.width / numerology.THIRTYTHREE;
   const strandA = [];
   const strandB = [];
 
-  for (let index = 0; index < samples; index += 1) {
-    const y = stage.y + index * verticalStep;
-    const angle = index * frequency;
-    const xA = stage.x + stage.width / 2 + Math.sin(angle) * amplitude;
-    const xB = stage.x + stage.width / 2 + Math.sin(angle + Math.PI) * amplitude;
-    strandA.push({ x: xA, y });
-    strandB.push({ x: xB, y });
+  for (let index = 0; index < sampleCount; index += 1) {
+    const t = index / (sampleCount - 1);
+    const angle = t * Math.PI * numerology.TWENTYTWO / numerology.SEVEN;
+    const y = stage.y + t * stage.height;
+    const offset = Math.sin(angle) * amplitude;
+    strandA.push({
+      x: clamp(spineX - offset - phaseOffset, stage.x, stage.x + stage.width),
+      y
+    });
+    strandB.push({
+      x: clamp(spineX + offset + phaseOffset, stage.x, stage.x + stage.width),
+      y
+    });
   }
 
   ctx.save();
-  ctx.lineWidth = Math.max(1.25, stage.width / 840);
-  ctx.strokeStyle = palette.layers[4];
+  ctx.lineWidth = Math.max(1.5, stage.width / numerology.ONEFORTYFOUR);
+  ctx.strokeStyle = withAlpha(palette.layers[4], 0.7);
   strokePolyline(ctx, strandA);
+  ctx.strokeStyle = withAlpha(palette.layers[5], 0.7);
   strokePolyline(ctx, strandB);
 
-  const rungInterval = Math.max(3, Math.floor(samples / numerology.TWENTYTWO));
-  ctx.strokeStyle = palette.layers[5];
-  ctx.lineWidth = Math.max(1, stage.width / 1024);
-  ctx.globalAlpha = 0.85;
-
-  for (let index = 0; index < samples; index += rungInterval) {
-    const a = strandA[index];
-    const b = strandB[index];
-    if (!a || !b) {
-      continue;
-    }
+  const rungCount = numerology.THIRTYTHREE;
+  ctx.strokeStyle = withAlpha(palette.ink, 0.25);
+  ctx.lineWidth = Math.max(1, stage.width / numerology.ONEFORTYFOUR);
+  for (let rung = 0; rung < rungCount; rung += 1) {
+    const t = rung / (rungCount - 1);
+    const index = Math.floor(t * (sampleCount - 1));
+    const start = strandA[index];
+    const end = strandB[index];
     ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
+    ctx.moveTo(start.x, start.y);
+    ctx.lineTo(end.x, end.y);
     ctx.stroke();
   }
 
@@ -706,33 +285,23 @@ function drawHelixLattice(ctx, settings) {
 }
 
 function drawPaletteNotice(ctx, settings) {
-  const { palette, stage } = settings;
-  const y = Math.max(20, stage.y - 18);
+  const { stage, palette, numerology } = settings;
+  const message = "Palette fallback active (data/palette.json missing).";
+  const padding = Math.max(8, stage.width / numerology.ONEFORTYFOUR);
+  const x = stage.x + padding;
+  const y = stage.y + padding;
+
   ctx.save();
-  ctx.fillStyle = palette.ink;
-  ctx.globalAlpha = 0.72;
-  ctx.font = "13px system-ui, -apple-system, 'Segoe UI', sans-serif";
+  ctx.font = "14px system-ui, sans-serif";
   ctx.textBaseline = "top";
-  ctx.fillText("Palette file missing — using built-in fallback.", stage.x, y);
+  const metrics = ctx.measureText(message);
+  const height = 18;
+
+  ctx.fillStyle = withAlpha(palette.bg, 0.85);
+  ctx.fillRect(x - padding, y - padding, metrics.width + padding * 2, height + padding * 2);
+  ctx.fillStyle = withAlpha(palette.ink, 0.75);
+  ctx.fillText(message, x, y);
   ctx.restore();
-}
-
-function insetRect(rect, factor) {
-  const clamped = Math.min(Math.max(factor, 0.1), 1);
-  const insetX = rect.width * (1 - clamped) / 2;
-  const insetY = rect.height * (1 - clamped) / 2;
-  return {
-    x: rect.x + insetX,
-    y: rect.y + insetY,
-    width: rect.width * clamped,
-    height: rect.height * clamped
-  };
-}
-
-function strokeCircle(ctx, x, y, radius) {
-  ctx.beginPath();
-  ctx.arc(x, y, radius, 0, Math.PI * 2);
-  ctx.stroke();
 }
 
 function strokePolyline(ctx, points) {
@@ -745,5 +314,93 @@ function strokePolyline(ctx, points) {
     ctx.lineTo(points[index].x, points[index].y);
   }
   ctx.stroke();
+}
 
+function computeMargin(width, height, numerology) {
+  const minSide = Math.min(width, height);
+  const harmonic = minSide / numerology.ELEVEN;
+  const cushion = (minSide / numerology.NINETYNINE) * numerology.THREE;
+  const floor = numerology.THIRTYTHREE;
+  return Math.max(floor, harmonic, cushion);
+}
+
+function createStage(width, height, margin) {
+  return {
+    x: margin,
+    y: margin,
+    width: Math.max(1, width - margin * 2),
+    height: Math.max(1, height - margin * 2)
+  };
+}
+
+function sanitiseDimension(value, fallback) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return fallback;
+  }
+  return numeric;
+}
+
+function normalisePalette(input) {
+  if (!input || typeof input !== "object") {
+    return DEFAULT_PALETTE;
+  }
+
+  const layers = [];
+  for (let index = 0; index < DEFAULT_PALETTE.layers.length; index += 1) {
+    const candidate = Array.isArray(input.layers) ? input.layers[index] : undefined;
+    layers.push(typeof candidate === "string" ? candidate : DEFAULT_PALETTE.layers[index]);
+  }
+
+  return {
+    bg: typeof input.bg === "string" ? input.bg : DEFAULT_PALETTE.bg,
+    ink: typeof input.ink === "string" ? input.ink : DEFAULT_PALETTE.ink,
+    layers
+  };
+}
+
+function normaliseNumerology(input) {
+  const base = { ...DEFAULT_NUMEROLOGY };
+  if (!input || typeof input !== "object") {
+    return base;
+  }
+  for (const key of Object.keys(base)) {
+    const numeric = Number(input[key]);
+    if (Number.isFinite(numeric) && numeric > 0) {
+      base[key] = numeric;
+    }
+  }
+  return base;
+}
+
+function withAlpha(hex, alpha) {
+  const rgb = hexToRgb(hex);
+  const safeAlpha = clamp(alpha, 0, 1);
+  if (!rgb) {
+    return `rgba(0, 0, 0, ${safeAlpha})`;
+  }
+  return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${safeAlpha})`;
+}
+
+function hexToRgb(hex) {
+  if (typeof hex !== "string") {
+    return null;
+  }
+  const normalised = hex.trim().replace(/^#/, "");
+  if (normalised.length !== 6) {
+    return null;
+  }
+  const value = Number.parseInt(normalised, 16);
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return {
+    r: (value >> 16) & 0xff,
+    g: (value >> 8) & 0xff,
+    b: value & 0xff
+  };
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
 }


### PR DESCRIPTION
## Summary
- rebuild the offline index shell with ND-safe status handling and palette fallback logic
- rewrite the helix renderer module with pure drawing helpers for the vesica field, tree scaffold, fibonacci curve, and helix lattice
- add inline palette fallback notice and numerology-driven spacing for deterministic geometry

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36d221c588328ad5a9749d4c282d7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Offline palette loading from a local file with safe fallback.
  - Deterministic, single-pass static rendering (no animation).
  - Clearer status updates during rendering.

- Refactor
  - Simplified rendering pipeline with unified settings for palette and numerology.
  - Centralized status handling and a single render invocation.
  - Reduced complexity for more predictable output.

- Style
  - Updated color tokens, minor box-shadow tweak, and refined header/notes text.

- Chores
  - Removed network dependencies for palettes and consolidated HTML/CSS to ND-safe defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->