### PR TITLE
Use offline-safe palette import

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,7 +3,7 @@
 Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe practices: no motion, soft yet legible contrast, and layered geometry that preserves depth. Everything works offline; double-clicking `index.html` is enough.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading (JSON import when opened via `file://`, `fetch` otherwise).
+- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading through an ES module import (safe for `file://`).
 - `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
 - `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
 
@@ -16,7 +16,7 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe pra
 ## Palette Notes
 - Default palette favors serene blues, teals, gold, and violet on deep charcoal for high readability.
 - Edit `data/palette.json` to adjust tones; keep six layer colors so each geometry band remains distinct.
-- Additional curated palettes now live in `data/palettes/` (for example `muse.json`). Copy one of those files over `data/palette.json` when you want to swap schemes without editing hex values by hand.
+- Additional curated palettes live in `data/palettes/` (for example `muse.json`). Copy one of those files over `data/palette.json` when you want to swap schemes without editing hex values by hand.
 - Removing the JSON file triggers the fallback palette and an inline notice, confirming the renderer is still safe.
 
 ## Using the Renderer

--- a/index.html
+++ b/index.html
@@ -32,25 +32,13 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadPalette(path) {
-      // Offline-first: prefer module import so file:// usage stays local-only.
+    async function loadPalette() {
+      // why: dynamic import keeps everything offline and avoids network primitives entirely.
       try {
-        const module = await import(path, { assert: { type: "json" } });
+        const module = await import("./data/palette.json", { assert: { type: "json" } });
         return module.default;
-      } catch (importError) {
-        // Browsers without JSON import assertions fall back to same-origin fetch.
-        if (window.location.protocol === "file:") {
-          return null;
-        }
-        try {
-          const response = await fetch(path, { cache: "no-store" });
-          if (!response.ok) {
-            return null;
-          }
-          return await response.json();
-        } catch (fetchError) {
-          return null;
-        }
+      } catch (error) {
+        return null;
       }
     }
 
@@ -72,8 +60,7 @@
       ONEFORTYFOUR: 144
     });
 
-    const palettePath = "./data/palette.json";
-    const palette = await loadPalette(palettePath);
+    const palette = await loadPalette();
     const activePalette = palette || FALLBACK_PALETTE;
     statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 


### PR DESCRIPTION
## Summary
- load the palette JSON through a dynamic module import so the renderer stays offline-only and avoids network primitives
- refresh README instructions to reflect the import-based palette loading while keeping the ND-safe workflow intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d446f1e1748328802fb411ff4b50f6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the color palette loading when opening the app directly from local files (file://), reducing errors and ensuring a consistent default fallback if loading fails.

* **Improvements**
  * Streamlined palette initialization for faster, more predictable startup behavior without requiring external network requests.

* **Documentation**
  * Clarified notes to indicate palettes are now loaded locally via a safe approach for file:// usage.
  * Minor wording cleanup for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->