### PR TITLE
Simplify offline palette loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,15 +28,18 @@
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const statusEl = document.getElementById("status");
+    const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-    async function loadPalette() {
-      // why: dynamic import keeps everything offline and avoids network primitives entirely.
+    async function loadJSON(path) {
+      // ND-safe: fetch stays local-only and fails gracefully when opened via file://.
       try {
-        const module = await import("./data/palette.json", { assert: { type: "json" } });
-        return module.default;
+        const response = await fetch(path, { cache: "no-store" });
+        if (!response.ok) {
+          throw new Error(String(response.status));
+        }
+        return await response.json();
       } catch (error) {
         return null;
       }
@@ -60,15 +63,15 @@
       ONEFORTYFOUR: 144
     });
 
-    const palette = await loadPalette();
-    const activePalette = palette || FALLBACK_PALETTE;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || FALLBACK_PALETTE;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    // ND-safe rationale: no motion, high readability, soft colors, layered order.
     renderHelix(ctx, {
       width: canvas.width,
       height: canvas.height,
-      palette: activePalette,
+      palette: active,
       NUM,
       missingPalette: !palette
     });


### PR DESCRIPTION
## Summary
- update the offline renderer entry point to load the palette JSON with a guarded local fetch
- preserve ND-safe fallback messaging and numerology constants while simplifying the status handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4940eb54c8328a176ddd273ba608a