### PR TITLE
fix: clean palette loader for offline use

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -32,34 +32,21 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-
-    async function loadJSON(path) {
-      // ND-safe: fetch stays local-only and fails gracefully when opened via file://.
+    async function loadPalette(path) {
+      // ND-safe: browsers may block fetch on file://; try fetch first, then module import.
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
           throw new Error(String(response.status));
         }
         return await response.json();
-      } catch (error) {
-        return null;
-
-    async function loadPalette(path) {
-      // Why: browsers treat file:// differently; try fetch first, then JSON modules.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(`status ${response.status}`);
-        }
-        return await response.json();
       } catch (fetchError) {
         try {
-          const module = await import(path, { assert: { type: "json" } });
+          const module = await import(path + "", { assert: { type: "json" } });
           return module.default;
         } catch (importError) {
           return null;
         }
-
       }
     }
 
@@ -81,20 +68,15 @@
       ONEFORTYFOUR: 144
     });
 
-
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || FALLBACK_PALETTE;
-=
     const palette = await loadPalette("./data/palette.json");
     const activePalette = palette || FALLBACK_PALETTE;
-
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order.
     renderHelix(ctx, {
       width: canvas.width,
       height: canvas.height,
-      palette: active,
+      palette: activePalette,
       NUM,
       missingPalette: !palette
     });


### PR DESCRIPTION
## Summary
- simplify the index module script and remove duplicate palette loaders
- ensure the offline palette fetch falls back gracefully without workflows

## Testing
- not run (static HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4aba31d7c832893c5d8b914997f70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of palette loading with a unified flow and robust fallback.
  * Clearer status messages when palette data fails to load or is unavailable.

* **Style**
  * Minor header punctuation update (em dash to hyphen) for consistency.
  * Slight adjustment to palette loading status text to align with the new flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->