### PR TITLE
Fix palette loading logic in offline renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -32,20 +32,8 @@
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
 
-
-    async function loadJSON(path) {
-      // ND-safe: fetch stays local-only and fails gracefully when opened via file://.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-
     async function loadPalette(path) {
-      // Why: browsers treat file:// differently; try fetch first, then JSON modules.
+      // ND-safe: browsers may restrict fetch for file://; try fetch, then JSON modules.
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
@@ -59,7 +47,6 @@
         } catch (importError) {
           return null;
         }
-
       }
     }
 
@@ -81,20 +68,15 @@
       ONEFORTYFOUR: 144
     });
 
-
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || FALLBACK_PALETTE;
-=
     const palette = await loadPalette("./data/palette.json");
     const activePalette = palette || FALLBACK_PALETTE;
-
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order.
     renderHelix(ctx, {
       width: canvas.width,
       height: canvas.height,
-      palette: active,
+      palette: activePalette,
       NUM,
       missingPalette: !palette
     });


### PR DESCRIPTION
## Summary
- clean up the palette loading helpers in `index.html`
- ensure file:// usage falls back to the embedded ND-safe palette
- keep status messaging and numerology constants intact for the renderer call

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4aca485188328af0feb20dafb6225

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More robust palette loading with an explicit fallback when a palette isn’t available, improving reliability in local and restricted environments.
- Bug Fixes
  - Ensures helix renders with the correct palette and gracefully handles missing palettes.
- Refactor
  - Simplified palette loading flow and standardized palette naming for clarity.
- Style
  - Minor font stack cleanup with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->