### PR TITLE
Stabilize offline palette fallback for Cosmic Helix renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -28,76 +28,57 @@
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
 
-    const elStatus = document.getElementById("status");
+    const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
-    const ctx = canvas.getContext("2d");
+    const context = canvas.getContext("2d");
 
+    if (!context) {
+      statusEl.textContent = "Canvas unsupported in this browser.";
+    } else {
+      const FALLBACK_PALETTE = Object.freeze({
+        // ND-safe fallback colors keep contrast gentle when palette.json is absent.
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      });
 
-    async function loadJSON(path) {
-      // ND-safe: fetch stays local-only and fails gracefully when opened via file://.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-
-    async function loadPalette(path) {
-      // Why: browsers treat file:// differently; try fetch first, then JSON modules.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(`status ${response.status}`);
-        }
-        return await response.json();
-      } catch (fetchError) {
+      async function loadPalette(path) {
+        // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
         try {
-          const module = await import(path, { assert: { type: "json" } });
-          return module.default;
-        } catch (importError) {
+          const response = await fetch(path, { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(`status ${response.status}`);
+          }
+          return await response.json();
+        } catch (error) {
           return null;
         }
-
       }
+
+      const NUM = Object.freeze({
+        THREE: 3,
+        SEVEN: 7,
+        NINE: 9,
+        ELEVEN: 11,
+        TWENTYTWO: 22,
+        THIRTYTHREE: 33,
+        NINETYNINE: 99,
+        ONEFORTYFOUR: 144
+      });
+
+      const palette = await loadPalette("./data/palette.json");
+      const activePalette = palette || FALLBACK_PALETTE;
+      statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+      // ND-safe rationale: single render, layered depth, no motion.
+      renderHelix(context, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: activePalette,
+        NUM,
+        missingPalette: !palette
+      });
     }
-
-    const FALLBACK_PALETTE = Object.freeze({
-      // ND-safe fallback colors in case the JSON file is absent or blocked.
-      bg: "#0b0b12",
-      ink: "#e8e8f0",
-      layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-    });
-
-    const NUM = Object.freeze({
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    });
-
-
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || FALLBACK_PALETTE;
-=
-    const palette = await loadPalette("./data/palette.json");
-    const activePalette = palette || FALLBACK_PALETTE;
-
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order.
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: active,
-      NUM,
-      missingPalette: !palette
-    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify the Cosmic Helix entry script so palette loading falls back cleanly when the JSON file is unavailable
- guard canvas context availability and document ND-safe defaults directly in the module setup

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d4b19c98b4832884e24478221780a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Built-in fallback color palette ensures visuals render even without network access.
- Bug Fixes
  - More reliable palette loading; gracefully handles failures and unsupported canvases.
  - Status text now updates accurately when a palette is missing.
- Refactor
  - Simplified loading and rendering flow for faster startup and improved stability.
- Style
  - Tweaked header and status text for clearer, more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->