### PR TITLE
Update static Pages workflow to peaceiris v4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -31,13 +31,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload entire repository
-          path: '.'
-      - name: Deploy to GitHub Pages
+      - name: GitHub Pages action
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: '.'


### PR DESCRIPTION
## Summary
- replace the static Pages deployment step to use the latest peaceiris/actions-gh-pages@v4.0.0
- retain checkout while simplifying the job to publish the repository contents directly

## Testing
- not run (workflow configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d4b7c0a5d0832892f1bd5b5c7e1447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Consolidated GitHub Pages deployment into a single action, resulting in quicker and more reliable site updates.
  - Reduced deployment complexity, lowering the risk of failures during publishing.
  - Improved consistency of page builds and deployments for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->