### PR TITLE
Add offline renderer bundler and Fly deploy assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# ---- build image ----
+FROM node:20-alpine AS builder
+WORKDIR /app
+
+# Toolchain (for native deps if needed)
+RUN apk add --no-cache python3 make g++ libc6-compat
+
+# Copy entire repo (simpler than partial COPY to avoid path drift)
+COPY . .
+
+# Speed up npm installs
+RUN npm set fund false && npm set audit false
+
+# Build all apps (root package.json supplies these scripts)
+RUN npm run build
+RUN npm run bundle:static
+
+# ---- runtime image ----
+FROM nginx:1.27-alpine AS runtime
+WORKDIR /usr/share/nginx/html
+
+# NGINX config
+COPY nginx.conf /etc/nginx/nginx.conf
+
+# Static files
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Fly uses $PORT
+ENV PORT=8080
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -2,6 +2,10 @@
 
 Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe practices: no motion, soft yet legible contrast, and layered geometry that preserves depth. Everything works offline; double-clicking `index.html` is enough.
 
+`scripts/build-renderer.mjs` keeps container builds reproducible:
+- `npm run build` writes `build/renderer-manifest.json` so the source set stays auditable.
+- `npm run bundle:static` hydrates `dist/` with the renderer and calm placeholders for `/stone-grimoire/` and `/circuitum99/`.
+
 ## Files
 - `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to JSON modules.
 - `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
@@ -23,6 +27,7 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe pra
 1. Keep the four files together.
 2. Double-click `index.html` (or use your browser's "Open File..." command).
 3. The canvas renders immediately; no network, build step, or workflow is required.
+4. For Fly deployments, run `npm run build && npm run bundle:static` to refresh `dist/` before shipping.
 
 ## Accessibility + ND-safe Choices
 - No animation, autoplay, or audio; every draw happens once.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -33,9 +33,6 @@
     const ctx = canvas.getContext("2d");
 
     async function loadPalette(path) {
-
-      // ND-safe: browsers may restrict fetch for file://; try fetch, then JSON modules.
-
       // ND-safe: browsers may block fetch on file://; try fetch first, then module import.
 
       try {

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,42 @@
+events {}
+
+http {
+  include       /etc/nginx/mime.types;
+  sendfile      on;
+  default_type  application/octet-stream;
+  gzip on;
+  gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
+  server {
+    listen 8080;
+    server_name _;
+
+    # Redirect root to main app path
+    location = / {
+      return 302 /cosmogenesis/;
+    }
+
+    # SPA fallback helper
+    map $uri $index_fallback {
+      default /index.html;
+    }
+
+    # Cosmogenesis
+    location /cosmogenesis/ {
+      alias /usr/share/nginx/html/cosmogenesis/;
+      try_files $uri $uri/ $index_fallback;
+    }
+
+    # Stone Grimoire
+    location /stone-grimoire/ {
+      alias /usr/share/nginx/html/stone-grimoire/;
+      try_files $uri $uri/ $index_fallback;
+    }
+
+    # Circuitum 99
+    location /circuitum99/ {
+      alias /usr/share/nginx/html/circuitum99/;
+      try_files $uri $uri/ $index_fallback;
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,13 +6,14 @@
   "scripts": {
     "build:index": "node scripts/build-corpus-index.mjs",
     "build:blessed": "node engines/blessed-build.js",
-    "cathedral:bundle": "node scripts/build-cathedral-codex.mjs",
+    "cathedral:bundle": "node tools/cathedral-bundle.mjs",
     "codex:local": "node packages/codex-14499/tools/gather-codex.mjs --config=packages/codex-14499/config/sources.local.json",
     "codex:org": "node packages/codex-14499/tools/gather-codex.mjs --config=packages/codex-14499/config/sources.github.json",
     "codex:report": "cat packages/codex-14499/dist/codex.report.md",
-    "cathedral:bundle": "node tools/cathedral-bundle.mjs",
     "cathedral:serve": "node tools/cathedral-bundle.mjs --serve",
-    "test": "echo \"No automated tests\""
+    "test": "echo \"No automated tests\"",
+    "build": "node scripts/build-renderer.mjs build",
+    "bundle:static": "node scripts/build-renderer.mjs bundle"
   },
   "keywords": [
     "esoteric",

--- a/scripts/build-renderer.mjs
+++ b/scripts/build-renderer.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/*
+  build-renderer.mjs
+  Offline-friendly bundler that prepares the Cosmic Helix renderer for container builds.
+
+  Prime Law observance:
+  - No network I/O; only local filesystem work.
+  - Small, pure helpers with explicit inputs keep edits safe offline.
+  - Comments explain ND-safe intent (no motion, calm fallbacks).
+*/
+
+import { promises as fs } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { createHash } from 'crypto';
+
+const PROJECT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const BUILD_DIR = join(PROJECT_ROOT, 'build');
+const DIST_DIR = join(PROJECT_ROOT, 'dist');
+
+const SOURCE_FILES = Object.freeze([
+  'index.html',
+  'js/helix-renderer.mjs',
+  'data/palette.json',
+  'README_RENDERER.md'
+]);
+
+const PLACEHOLDERS = Object.freeze([
+  { key: 'stone-grimoire', title: 'Stone Grimoire', body: 'Static grimoire shell - content supplied in offline rituals.' },
+  { key: 'circuitum99', title: 'Circuitum 99', body: 'Circuit map placeholder - keeps routes alive without motion.' }
+]);
+
+const ENCODING = 'utf8';
+
+async function main(argv) {
+  const phase = readPhase(argv);
+  if (phase === 'build') {
+    await writeManifest();
+  } else if (phase === 'bundle') {
+    await bundleStatic();
+  } else {
+    throw new Error('Unknown phase for build-renderer.mjs');
+  }
+}
+
+function readPhase(argv) {
+  const candidate = argv[2];
+  if (candidate === 'build' || candidate === 'bundle') {
+    return candidate;
+  }
+  // Default to bundle so manual runs hydrate dist/ for local preview.
+  return 'bundle';
+}
+
+async function writeManifest() {
+  const entries = [];
+  for (const relativePath of SOURCE_FILES) {
+    const absolutePath = join(PROJECT_ROOT, relativePath);
+    const stats = await fs.stat(absolutePath);
+    const hash = await hashFile(absolutePath);
+    entries.push({
+      path: relativePath,
+      bytes: stats.size,
+      sha256: hash
+    });
+  }
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    rationale: 'Manifest documents renderer inputs so edits remain auditable offline.',
+    files: entries
+  };
+
+  await ensureDir(BUILD_DIR);
+  await fs.writeFile(join(BUILD_DIR, 'renderer-manifest.json'), JSON.stringify(manifest, null, 2) + '\n', ENCODING);
+}
+
+async function bundleStatic() {
+  await resetDir(DIST_DIR);
+  await copyRendererBundle('cosmogenesis');
+  for (const placeholder of PLACEHOLDERS) {
+    await ensurePlaceholder(placeholder);
+  }
+  await fs.writeFile(join(DIST_DIR, 'README.txt'), buildDistReadme(), ENCODING);
+}
+
+async function copyRendererBundle(targetKey) {
+  const targetDir = join(DIST_DIR, targetKey);
+  await ensureDir(targetDir);
+  await copyFile('index.html', join(targetDir, 'index.html'));
+  await copyDir('js', join(targetDir, 'js'));
+  await copyDir('data', join(targetDir, 'data'));
+  await copyFile('README_RENDERER.md', join(targetDir, 'README_RENDERER.md'));
+}
+
+async function ensurePlaceholder(spec) {
+  const targetDir = join(DIST_DIR, spec.key);
+  await ensureDir(targetDir);
+  const html = buildPlaceholderHtml(spec);
+  await fs.writeFile(join(targetDir, 'index.html'), html, ENCODING);
+}
+
+function buildPlaceholderHtml(spec) {
+  return [
+    '<!doctype html>',
+    '<html lang="en">',
+    '<head>',
+    '  <meta charset="utf-8">',
+    '  <title>' + spec.title + ' (Offline Placeholder)</title>',
+    '  <meta name="viewport" content="width=device-width,initial-scale=1">',
+    '  <meta name="color-scheme" content="light dark">',
+    '  <style>',
+    '    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }',
+    '    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:16px/1.5 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }',
+    '    main { max-width:640px; margin:15vh auto; padding:24px; border:1px solid #1d1d2a; background:rgba(13,13,20,0.92); }',
+    '    h1 { margin-top:0; font-size:1.8rem; }',
+    '    p { color:var(--muted); }',
+    '    a { color:var(--ink); }',
+    '  </style>',
+    '</head>',
+    '<body>',
+    '  <main>',
+    '    <h1>' + spec.title + '</h1>',
+    '    <p>' + spec.body + '</p>',
+    '    <p><a href="/cosmogenesis/">Return to Cosmogenesis renderer</a></p>',
+    '  </main>',
+    '</body>',
+    '</html>',
+    ''
+  ].join('\n');
+}
+
+async function copyFile(relativeSource, absoluteTarget) {
+  const absoluteSource = join(PROJECT_ROOT, relativeSource);
+  await ensureDir(dirname(absoluteTarget));
+  await fs.copyFile(absoluteSource, absoluteTarget);
+}
+
+async function copyDir(relativeSource, absoluteTarget) {
+  const absoluteSource = join(PROJECT_ROOT, relativeSource);
+  await fs.cp(absoluteSource, absoluteTarget, { recursive: true });
+}
+
+async function ensureDir(path) {
+  await fs.mkdir(path, { recursive: true });
+}
+
+async function resetDir(path) {
+  await fs.rm(path, { recursive: true, force: true });
+  await ensureDir(path);
+}
+
+async function hashFile(path) {
+  const data = await fs.readFile(path);
+  const hash = createHash('sha256');
+  hash.update(data);
+  return hash.digest('hex');
+}
+
+function buildDistReadme() {
+  return [
+    'Cosmic Helix dist bundle (offline)',
+    '',
+    'Generated by scripts/build-renderer.mjs.',
+    'Routes:',
+    '  /cosmogenesis/  -> full renderer with layered geometry.',
+    '  /stone-grimoire/ -> placeholder shell kept static for ND-safe calm.',
+    '  /circuitum99/   -> placeholder shell so Fly routes do not 404.',
+    '',
+    'All assets stay offline. Update data/palette.json then rerun npm run bundle:static.',
+    ''
+  ].join('\n');
+}
+
+await main(process.argv);


### PR DESCRIPTION
## Summary
- add a hardened multi-stage Dockerfile and nginx config for Fly static hosting
- introduce a build-renderer script with npm build/bundle tasks to stage cosmogenesis assets and calm placeholders
- document the workflow in README_RENDERER and tidy the renderer entry HTML comment/typography

## Testing
- npm run build
- npm run bundle:static

------
https://chatgpt.com/codex/tasks/task_e_68d4b4eded148328bc58260f6e57fd58

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added containerized production image serving the app via Nginx with gzip.
  - Configured SPA routing for /cosmogenesis, /stone-grimoire, and /circuitum99 with index fallbacks.
  - Root path redirects to /cosmogenesis; default port set to 8080.

- Documentation
  - Added guidance on reproducible builds and deployment, including steps to refresh static assets before shipping.

- Chores
  - Introduced npm scripts: build and bundle:static for generating the renderer manifest and static bundle.
  - Standardized bundle script mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->