### PR TITLE
Add Codex14499 offline renderer entry

### DIFF
--- a/apps/web/Codex14499.html
+++ b/apps/web/Codex14499.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer - Codex14499 Node</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> - Codex14499 reference copy</div>
+    <div class="status" id="status">Loading palette...</div>
+  </header>
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">Offline mirror of the main renderer: Vesica field, Tree-of-Life, Fibonacci curve, and double-helix lattice. Static layers, ND-safe palette.</p>
+  <script type="module">
+    import { renderHelix } from "../../js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    if (!ctx) {
+      elStatus.textContent = "Canvas unsupported in this browser.";
+    } else {
+      const FALLBACK = Object.freeze({
+        bg: "#0b0b12",
+        ink: "#e8e8f0",
+        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      });
+
+      async function loadPalette(path) {
+        try {
+          const response = await fetch(path, { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error(String(response.status));
+          }
+          return await response.json();
+        } catch (error) {
+          return null;
+        }
+      }
+
+      const NUM = Object.freeze({
+        THREE: 3,
+        SEVEN: 7,
+        NINE: 9,
+        ELEVEN: 11,
+        TWENTYTWO: 22,
+        THIRTYTHREE: 33,
+        NINETYNINE: 99,
+        ONEFORTYFOUR: 144
+      });
+
+      const palette = await loadPalette("../../data/palette.json");
+      const active = palette || FALLBACK;
+      elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+      renderHelix(ctx, {
+        width: canvas.width,
+        height: canvas.height,
+        palette: active,
+        NUM,
+        missingPalette: !palette
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an offline Codex14499 HTML entry point that mirrors the existing Cosmic Helix renderer
- ensure the mirror loads shared numerology constants, palettes, and rendering routines with local fallbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e33335dc83289bde98be4eb0aff7