### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
     "offline"
   ],
   "author": "",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "sanitize-html": "^2.17.0"
+}
 }

--- a/tools/cathedral-bundle.mjs
+++ b/tools/cathedral-bundle.mjs
@@ -16,6 +16,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { createHash, randomUUID } from 'crypto';
 import http from 'http';
+import sanitizeHtml from 'sanitize-html';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
@@ -1558,7 +1559,7 @@ function sanitizeNodePayload(body) {
 }
 
 function stripHtml(text) {
-  return text.replace(/<[^>]+>/g, '');
+  return sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });
 }
 
 function broadcastUpdate(etag) {


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/cathedral/security/code-scanning/2](https://github.com/Bekalah/cathedral/security/code-scanning/2)

The best way to fix this is to use a well-tested, dedicated HTML sanitization library such as `sanitize-html`, which correctly removes dangerous tags (including `<script>`) and handles corner cases that simple regexes routinely fail on. If adding a dependency is undesirable, a safer fallback is to re-apply the regular expression repeatedly until no changes are made (multi-pass), or to rewrite it to operate at the character level, removing all `<` and `>` characters (though this is destructive and can harm allowed content). The ideal fix within the shown code snippet is to use `sanitize-html` module’s default behavior to sanitize user Markdown input, completely removing tags like `<script>` and any other injectable HTML.

The fix requires:
- Adding an import for `sanitize-html` at the top of the file.
- Refactoring the `stripHtml` function at line 1560–1562 to use `sanitizeHtml` library.
- No changes to other logic or callers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
