### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/apps/hub/js/corpus.js
+++ b/apps/hub/js/corpus.js
@@ -6,6 +6,17 @@
 
 import MiniSearch from "../../shared/lib/minisearch-lite.mjs";
 
+// Utility function to escape HTML special characters
+function escapeHTML(str) {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/`/g, '&#96;');
+}
+
 let mini = null;
 
 function resolveElement(target) {
@@ -65,7 +76,7 @@ export function attachCorpusSearch({ input, results, minLength = 2, renderResult
     }
     const matches = corpusSearch(value);
     if (!matches.length) {
-      resultsEl.innerHTML = `<li>No matches for <code>${value}</code></li>`;
+      resultsEl.innerHTML = `<li>No matches for <code>${escapeHTML(value)}</code></li>`;
       return;
     }
     resultsEl.innerHTML = matches.map(renderer).join("");


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/cathedral/security/code-scanning/3](https://github.com/Bekalah/cathedral/security/code-scanning/3)

To fix this problem, user-supplied text (`value`) must be properly escaped before it is inserted as HTML into the DOM. The best general fix is to HTML-escape any special characters (`&`, `<`, `>`, `"`, `'`, `` ` ``) in `value` before interpolation. This ensures that any user-supplied string is shown as text and not interpreted as HTML or script, even when inserted as part of an HTML fragment. 

In this file, define a small utility function (e.g., `escapeHTML`) for escaping HTML, and use it to sanitize `value` in the relevant template literal on line 68. Insert the function somewhere near the top of the file (e.g., after the import), and wrap `${value}` as `${escapeHTML(value)}`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
