### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete multi-character sanitization

### DIFF
--- a/apps/hub/js/source-packs.js
+++ b/apps/hub/js/source-packs.js
@@ -10,10 +10,19 @@ function ensureModal() {
   if (modalRenderer) {
     return modalRenderer;
   }
+  // Helper to repeatedly remove all HTML tags
+  function stripAllTags(str) {
+    let prev;
+    do {
+      prev = str;
+      str = str.replace(/<[^>]+>/g, "");
+    } while (str !== prev);
+    return str;
+  }
   return (html) => {
     const win = window.open("", "_blank");
     if (!win) {
-      alert("Source pack:\n" + html.replace(/<[^>]+>/g, ""));
+      alert("Source pack:\n" + stripAllTags(html));
       return;
     }
     win.document.write(`<title>Source Pack</title><body>${html}</body>`);


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/cathedral/security/code-scanning/1](https://github.com/Bekalah/cathedral/security/code-scanning/1)

To fix this problem, we must ensure that all HTML tags—even those that may form newly after some have been removed—are fully stripped out. The simple way to do this, without introducing a new dependency, is to repeat the tag-removal replacement until no more matches are found. This method addresses cases where removing one set of tags reveals more tags, as described in the examples.

**How to fix:**
- Replace `html.replace(/<[^>]+>/g, "")` with code that repeatedly applies the replacement until the string no longer changes.
- Implement an inline helper function (such as `stripAllTags`) for this purpose, defined only within the relevant scope (function or file).
- Limit changes only to the area around the affected line (line 16 in `ensureModal`).
- No new external dependencies are needed, and only standard JS methods are used.

**Specifically:**
- Define a helper function, e.g., `function stripAllTags(input) {...}`, that loops until there are no more tags to remove.
- Replace the one-liner in the alert call to call this new function instead.
- Add the helper within the same file, suitable for calling from `ensureModal`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
