### PR TITLE
Fix index palette fallback and doc

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -7,7 +7,7 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe pra
 - `npm run bundle:static` hydrates `dist/` with the renderer and calm placeholders for `/stone-grimoire/` and `/circuitum99/`.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to JSON modules.
+- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to a built-in palette.
 - `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
 - `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
 

--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -30,77 +30,53 @@
 
     const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
-    const context = canvas.getContext("2d");
+    const ctx = canvas.getContext("2d");
 
-
-    if (!context) {
+    if (!ctx) {
       statusEl.textContent = "Canvas unsupported in this browser.";
-    } else {
-      const FALLBACK_PALETTE = Object.freeze({
+      throw new Error("Canvas context unavailable");
+    }
+
+    const DEFAULTS = Object.freeze({
+      palette: {
         // ND-safe fallback colors keep contrast gentle when palette.json is absent.
         bg: "#0b0b12",
         ink: "#e8e8f0",
         layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      });
+      }
+    });
 
-      async function loadPalette(path) {
-        // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
-        try {
-          const response = await fetch(path, { cache: "no-store" });
-          if (!response.ok) {
-            throw new Error(`status ${response.status}`);
-          }
-          return await response.json();
-        } catch (error) {
-
-    async function loadPalette(path) {
-      // ND-safe: browsers may block fetch on file://; try fetch first, then module import.
-
+    async function loadJSON(path) {
+      // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
       try {
         const response = await fetch(path, { cache: "no-store" });
         if (!response.ok) {
           throw new Error(String(response.status));
         }
         return await response.json();
-      } catch (fetchError) {
-        try {
-          const module = await import(path + "", { assert: { type: "json" } });
-          return module.default;
-        } catch (importError) {
-
-          return null;
-        }
+      } catch (error) {
+        return null;
       }
-
-      const NUM = Object.freeze({
-        THREE: 3,
-        SEVEN: 7,
-        NINE: 9,
-        ELEVEN: 11,
-        TWENTYTWO: 22,
-        THIRTYTHREE: 33,
-        NINETYNINE: 99,
-        ONEFORTYFOUR: 144
-      });
-
-      const palette = await loadPalette("./data/palette.json");
-      const activePalette = palette || FALLBACK_PALETTE;
-      statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-
-      // ND-safe rationale: single render, layered depth, no motion.
-      renderHelix(context, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-        missingPalette: !palette
-      });
     }
 
-    const palette = await loadPalette("./data/palette.json");
-    const activePalette = palette || FALLBACK_PALETTE;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const palette = await loadJSON("./data/palette.json");
+    const activePalette = palette || DEFAULTS.palette;
+    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Harmonise document colors with the palette so the canvas sits in a matching field.
+    document.documentElement.style.setProperty("--bg", activePalette.bg || DEFAULTS.palette.bg);
+    document.documentElement.style.setProperty("--ink", activePalette.ink || DEFAULTS.palette.ink);
+
+    const NUM = Object.freeze({
+      THREE: 3,
+      SEVEN: 7,
+      NINE: 9,
+      ELEVEN: 11,
+      TWENTYTWO: 22,
+      THIRTYTHREE: 33,
+      NINETYNINE: 99,
+      ONEFORTYFOUR: 144
+    });
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order.
     renderHelix(ctx, {
@@ -110,7 +86,6 @@
       NUM,
       missingPalette: !palette
     });
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify palette loading in `index.html` so offline use falls back to the embedded ND-safe palette
- sync the page chrome with the active palette for a consistent static field
- update the renderer README to describe the built-in palette fallback accurately

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68d4ec3115d88328a994a382847b1c58