### PR TITLE
Refine offline helix renderer entrypoint

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,36 +1,29 @@
-# Cosmic Helix Renderer (Offline)
+# Cosmic Helix Renderer (Offline, ND-safe)
 
-Static HTML + Canvas renderer that honors the Cosmic-Helix spec with ND-safe practices: no motion, soft yet legible contrast, and layered geometry that preserves depth. Everything works offline; double-clicking `index.html` is enough.
-
-`scripts/build-renderer.mjs` keeps container builds reproducible:
-- `npm run build` writes `build/renderer-manifest.json` so the source set stays auditable.
-- `npm run bundle:static` hydrates `dist/` with the renderer and calm placeholders for `/stone-grimoire/` and `/circuitum99/`.
+Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geometry and sensory-calming choices. Everything runs offline: double-clicking `index.html` is enough.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to JSON modules.
-- `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
-- `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
+- `index.html` - entry point with a 1440x900 canvas, palette loader, and ND-safe status copy.
+- `js/helix-renderer.mjs` - pure ES module that draws the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice in that order.
+- `data/palette.json` - editable palette file. Remove it to test the inline fallback notice; the renderer stays safe.
 
-## Layer Breakdown
-1. **Vesica field** - Seven-by-nine lattice of intersecting circles (constants 7 and 9) with harmonic rings to ground the grid.
-2. **Tree-of-Life scaffold** - Ten sephirot nodes with twenty-two connective paths. Layout ratios use constants 3, 7, 9, 11, 22, 33, 99, and 144.
-3. **Fibonacci curve** - Static polyline approximation of a logarithmic spiral (phi scaled with constants 3, 11, 22, 33, 99).
-4. **Double-helix lattice** - Ninety-nine point samples per strand with mirrored phase offsets (constants 7, 11, 22, 33, 99, 144) and calm rungs.
+## Rendered Layers
+1. **Vesica field** - Seven by nine circle lattice using constants 7 and 9 for grounding repetition.
+2. **Tree-of-Life scaffold** - Ten sephirot nodes with twenty-two connective paths. Layout ratios weave constants 3, 7, 9, 11, 22, 33, 99, and 144.
+3. **Fibonacci curve** - Logarithmic spiral approximation sampled with constants 11, 22, 33, and 99 for calm growth.
+4. **Double-helix lattice** - Phase-shifted strands sampled ninety-nine times with thirty-three crossbars; ratios lean on constants 7, 11, 22, 33, 99, and 144.
 
 ## Palette Notes
 - Default palette favors serene blues, teals, gold, and violet on deep charcoal for high readability.
 - Edit `data/palette.json` to adjust tones; keep six layer colors so each geometry band remains distinct.
-- Additional curated palettes live in `data/palettes/` (for example `muse.json`). Copy one of those files over `data/palette.json` when you want to swap schemes without editing hex values by hand.
-- Removing the JSON file triggers the fallback palette and an inline notice, confirming the renderer is still safe.
+- Additional curated palettes live in `data/palettes/`. Copy one over `data/palette.json` to swap schemes.
 
-## Using the Renderer
+## Usage (Offline)
 1. Keep the four files together.
-2. Double-click `index.html` (or use your browser's "Open File..." command).
-3. The canvas renders immediately; no network, build step, or workflow is required.
-4. For Fly deployments, run `npm run build && npm run bundle:static` to refresh `dist/` before shipping.
+2. Double-click `index.html` (or use a browser "Open File" command).
+3. The canvas renders immediately. No network, build step, or workflow exists here.
 
-## Accessibility + ND-safe Choices
-- No animation, autoplay, or audio; every draw happens once.
-- Clearspace is computed from numerology constants to keep forms away from edges.
-- Palette choices sustain contrast above WCAG 2.1 AA while staying gentle on sensory systems.
-- Layer order preserves depth: Vesica base, Tree-of-Life structure, Fibonacci growth, Helix lattice crown.
+## Accessibility and ND-safe Choices
+- No animation, audio, or autoplay; drawing happens once.
+- Comments document why each layer stays static and how contrast stays readable.
+- Layer order preserves depth: Vesica base, Tree-of-Life structure, Fibonacci growth, Helix crown.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -19,7 +19,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div class="status" id="status">Preparing canvas...</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -30,44 +30,29 @@
 
     const statusEl = document.getElementById("status");
     const canvas = document.getElementById("stage");
-    const context = canvas.getContext("2d");
+    const ctx = canvas.getContext("2d");
 
-
-    if (!context) {
+    if (!ctx) {
       statusEl.textContent = "Canvas unsupported in this browser.";
     } else {
-      const FALLBACK_PALETTE = Object.freeze({
-        // ND-safe fallback colors keep contrast gentle when palette.json is absent.
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+      const defaults = Object.freeze({
+        palette: {
+          // ND-safe: fallback palette mirrors layered calm when palette.json is absent or blocked.
+          bg: "#0b0b12",
+          ink: "#e8e8f0",
+          layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+        }
       });
 
       async function loadPalette(path) {
-        // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
+        // ND-safe: browsers may refuse file:// fetches; returning null keeps rendering predictable.
         try {
           const response = await fetch(path, { cache: "no-store" });
           if (!response.ok) {
-            throw new Error(`status ${response.status}`);
+            throw new Error(String(response.status));
           }
           return await response.json();
         } catch (error) {
-
-    async function loadPalette(path) {
-      // ND-safe: browsers may block fetch on file://; try fetch first, then module import.
-
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (fetchError) {
-        try {
-          const module = await import(path + "", { assert: { type: "json" } });
-          return module.default;
-        } catch (importError) {
-
           return null;
         }
       }
@@ -83,34 +68,21 @@
         ONEFORTYFOUR: 144
       });
 
-      const palette = await loadPalette("./data/palette.json");
-      const activePalette = palette || FALLBACK_PALETTE;
-      statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+      (async () => {
+        const palette = await loadPalette("./data/palette.json");
+        const activePalette = palette || defaults.palette;
+        statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-
-      // ND-safe rationale: single render, layered depth, no motion.
-      renderHelix(context, {
-        width: canvas.width,
-        height: canvas.height,
-        palette: activePalette,
-        NUM,
-        missingPalette: !palette
-      });
+        // ND-safe rationale: single draw call, layered order preserves calm depth, no motion ever introduced.
+        renderHelix(ctx, {
+          width: canvas.width,
+          height: canvas.height,
+          palette: activePalette,
+          NUM,
+          missingPalette: !palette
+        });
+      })();
     }
-
-    const palette = await loadPalette("./data/palette.json");
-    const activePalette = palette || FALLBACK_PALETTE;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order.
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      missingPalette: !palette
-    });
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- clean the HTML entrypoint so it loads palettes safely and renders the helix stack once without duplication
- document offline usage and layer intent in README_RENDERER.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f44c74fc8328acfbe4e744e60e7f