### PR TITLE
Clean renderer entrypoint and documentation

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,15 +1,12 @@
 # Cosmic Helix Renderer (Offline, ND-safe)
 
-Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geometry and sensory-calming choices. Everything runs offline: double-clicking `index.html` is enough.
+Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geometry and sensory calming choices. Everything runs offline: double-clicking `index.html` is enough.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas, palette loader, and ND-safe status copy.
+- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading with a built-in fallback.
 - `js/helix-renderer.mjs` - pure ES module that draws the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice in that order.
-- `data/palette.json` - editable palette file. Remove it to test the inline fallback notice; the renderer stays safe.
-
-- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to a built-in palette.
-- `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
-- `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
+- `data/palette.json` - editable ND-safe palette. If missing, the renderer falls back to embedded colors and paints a gentle inline notice.
+- `data/palettes/` - optional curated palettes to copy over `data/palette.json`.
 
 ## Rendered Layers
 1. **Vesica field** - Seven by nine circle lattice using constants 7 and 9 for grounding repetition.
@@ -18,9 +15,9 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geo
 4. **Double-helix lattice** - Phase-shifted strands sampled ninety-nine times with thirty-three crossbars; ratios lean on constants 7, 11, 22, 33, 99, and 144.
 
 ## Palette Notes
-- Default palette favors serene blues, teals, gold, and violet on deep charcoal for high readability.
+- Default palette favors serene blues, teals, gold, and violet on deep charcoal for readability.
 - Edit `data/palette.json` to adjust tones; keep six layer colors so each geometry band remains distinct.
-- Additional curated palettes live in `data/palettes/`. Copy one over `data/palette.json` to swap schemes.
+- To test the fallback, temporarily rename or remove `data/palette.json`. The canvas will render with embedded colors and note the fallback status.
 
 ## Usage (Offline)
 1. Keep the four files together.
@@ -28,6 +25,6 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geo
 3. The canvas renders immediately. No network, build step, or workflow exists here.
 
 ## Accessibility and ND-safe Choices
-- No animation, audio, or autoplay; drawing happens once.
+- No animation, audio, or autoplay; drawing happens once per load.
 - Comments document why each layer stays static and how contrast stays readable.
 - Layer order preserves depth: Vesica base, Tree-of-Life structure, Fibonacci growth, Helix crown.

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <style>
     /* ND-safe: calm contrast, no motion, generous spacing */
     :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
-    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,sans-serif; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; }
     header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
     .status { color:var(--muted); font-size:12px; }
     #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
@@ -18,17 +18,12 @@
 </head>
 <body>
   <header>
-
     <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Preparing canvas...</div>
-
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
-
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
-  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libraries. Open this file directly.</p>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";
@@ -39,19 +34,18 @@
 
     if (!ctx) {
       statusEl.textContent = "Canvas unsupported in this browser.";
-
     } else {
-      const defaults = Object.freeze({
+      const DEFAULTS = Object.freeze({
         palette: {
-          // ND-safe: fallback palette mirrors layered calm when palette.json is absent or blocked.
+          // ND-safe fallback: mirrors layered calm when palette.json cannot be fetched offline.
           bg: "#0b0b12",
           ink: "#e8e8f0",
           layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
         }
       });
 
-      async function loadPalette(path) {
-        // ND-safe: browsers may refuse file:// fetches; returning null keeps rendering predictable.
+      async function loadJSON(path) {
+        // ND-safe: local fetch only; if file:// security blocks it we fall back silently.
         try {
           const response = await fetch(path, { cache: "no-store" });
           if (!response.ok) {
@@ -75,11 +69,15 @@
       });
 
       (async () => {
-        const palette = await loadPalette("./data/palette.json");
-        const activePalette = palette || defaults.palette;
+        const palette = await loadJSON("./data/palette.json");
+        const activePalette = palette || DEFAULTS.palette;
         statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-        // ND-safe rationale: single draw call, layered order preserves calm depth, no motion ever introduced.
+        // Harmonise document colors with the palette so the canvas sits in a matching field.
+        document.documentElement.style.setProperty("--bg", activePalette.bg || DEFAULTS.palette.bg);
+        document.documentElement.style.setProperty("--ink", activePalette.ink || DEFAULTS.palette.ink);
+
+        // ND-safe rationale: one draw call, layered order keeps depth without motion.
         renderHelix(ctx, {
           width: canvas.width,
           height: canvas.height,
@@ -89,60 +87,6 @@
         });
       })();
     }
-
-      throw new Error("Canvas context unavailable");
-    }
-
-    const DEFAULTS = Object.freeze({
-      palette: {
-        // ND-safe fallback colors keep contrast gentle when palette.json is absent.
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    });
-
-    async function loadJSON(path) {
-      // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    const palette = await loadJSON("./data/palette.json");
-    const activePalette = palette || DEFAULTS.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Harmonise document colors with the palette so the canvas sits in a matching field.
-    document.documentElement.style.setProperty("--bg", activePalette.bg || DEFAULTS.palette.bg);
-    document.documentElement.style.setProperty("--ink", activePalette.ink || DEFAULTS.palette.ink);
-
-    const NUM = Object.freeze({
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    });
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order.
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      missingPalette: !palette
-    });
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- clean up index.html to remove duplicate script merges and harmonise palette fallback handling
- refresh README_RENDERER.md to reflect the unified offline renderer layout and palette guidance

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5de72ba38832890fd7217010bcd68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically applies the selected color palette to the UI, with a safe default when no palette is found.
  * More resilient behavior when offline or when palette data is unavailable.

* **Documentation**
  * Clarified README wording and terminology, including palette fallback behavior and accessibility note (“drawing happens once per load”).
  * Updated descriptions for entry points and palette guidance to reflect embedded colors and fallback notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->