### PR TITLE
Clean renderer entry point and docs

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -3,19 +3,15 @@
 Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geometry and sensory-calming choices. Everything runs offline: double-clicking `index.html` is enough.
 
 ## Files
-- `index.html` - entry point with a 1440x900 canvas, palette loader, and ND-safe status copy.
-- `js/helix-renderer.mjs` - pure ES module that draws the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice in that order.
-- `data/palette.json` - editable palette file. Remove it to test the inline fallback notice; the renderer stays safe.
-
-- `index.html` - entry point with a 1440x900 canvas, calm status line, and local palette loading that first tries `fetch` then falls back to a built-in palette.
-- `js/helix-renderer.mjs` - pure ES module that draws the Vesica lattice, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice.
-- `data/palette.json` - editable ND-safe palette. If missing or blocked, the renderer falls back to an embedded palette and paints a gentle inline notice.
+- `index.html` – entry point with a 1440x900 canvas, palette loader, and ND-safe status copy.
+- `js/helix-renderer.mjs` – pure ES module that draws the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice in that order.
+- `data/palette.json` – editable palette file. Remove it to test the inline fallback notice; the renderer stays safe.
 
 ## Rendered Layers
-1. **Vesica field** - Seven by nine circle lattice using constants 7 and 9 for grounding repetition.
-2. **Tree-of-Life scaffold** - Ten sephirot nodes with twenty-two connective paths. Layout ratios weave constants 3, 7, 9, 11, 22, 33, 99, and 144.
-3. **Fibonacci curve** - Logarithmic spiral approximation sampled with constants 11, 22, 33, and 99 for calm growth.
-4. **Double-helix lattice** - Phase-shifted strands sampled ninety-nine times with thirty-three crossbars; ratios lean on constants 7, 11, 22, 33, 99, and 144.
+1. **Vesica field** – Seven by nine circle lattice using constants 7 and 9 for grounding repetition.
+2. **Tree-of-Life scaffold** – Ten sephirot nodes with twenty-two connective paths. Layout ratios weave constants 3, 7, 9, 11, 22, 33, 99, and 144.
+3. **Fibonacci curve** – Logarithmic spiral approximation sampled with constants 11, 22, 33, and 99 for calm growth.
+4. **Double-helix lattice** – Phase-shifted strands sampled ninety-nine times with thirty-three crossbars; ratios lean on constants 7, 11, 22, 33, 99, and 144.
 
 ## Palette Notes
 - Default palette favors serene blues, teals, gold, and violet on deep charcoal for high readability.

--- a/index.html
+++ b/index.html
@@ -18,13 +18,8 @@
 </head>
 <body>
   <header>
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Preparing canvas...</div>
-
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
-
+    <div class="status" id="status">Preparing canvas…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -39,57 +34,6 @@
 
     if (!ctx) {
       statusEl.textContent = "Canvas unsupported in this browser.";
-
-    } else {
-      const defaults = Object.freeze({
-        palette: {
-          // ND-safe: fallback palette mirrors layered calm when palette.json is absent or blocked.
-          bg: "#0b0b12",
-          ink: "#e8e8f0",
-          layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-        }
-      });
-
-      async function loadPalette(path) {
-        // ND-safe: browsers may refuse file:// fetches; returning null keeps rendering predictable.
-        try {
-          const response = await fetch(path, { cache: "no-store" });
-          if (!response.ok) {
-            throw new Error(String(response.status));
-          }
-          return await response.json();
-        } catch (error) {
-          return null;
-        }
-      }
-
-      const NUM = Object.freeze({
-        THREE: 3,
-        SEVEN: 7,
-        NINE: 9,
-        ELEVEN: 11,
-        TWENTYTWO: 22,
-        THIRTYTHREE: 33,
-        NINETYNINE: 99,
-        ONEFORTYFOUR: 144
-      });
-
-      (async () => {
-        const palette = await loadPalette("./data/palette.json");
-        const activePalette = palette || defaults.palette;
-        statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-        // ND-safe rationale: single draw call, layered order preserves calm depth, no motion ever introduced.
-        renderHelix(ctx, {
-          width: canvas.width,
-          height: canvas.height,
-          palette: activePalette,
-          NUM,
-          missingPalette: !palette
-        });
-      })();
-    }
-
       throw new Error("Canvas context unavailable");
     }
 
@@ -142,7 +86,6 @@
       NUM,
       missingPalette: !palette
     });
-
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- streamline `index.html` loader to use a single ND-safe palette fallback and status message
- synchronize document colors with the active palette before rendering
- deduplicate README_RENDERER documentation so the offline usage steps stay concise

## Testing
- not run (static HTML/JS change)


------
https://chatgpt.com/codex/tasks/task_e_68d5f00775f08328a202ee144a5cabde

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized palette loading from palette.json with fallback to defaults and application to CSS variables.
  - Updated initialization message to “Preparing canvas…” and streamlined render sequence.

- Documentation
  - Standardized geometry terminology (Vesica field, Tree-of-Life scaffold, Fibonacci curve, double-helix lattice).
  - Reformatted Rendered Layers list for clarity.
  - Expanded Palette Notes with six-layer guidance and palette swapping references.
  - Added Offline Usage and Accessibility steps and ND-safe wording updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->