### PR TITLE
Add fractal synthesis presets and renderers

### DIFF
--- a/Codex14499.html
+++ b/Codex14499.html
@@ -1,0 +1,162 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Codex 144.99 — Fractal Synthesis Engine</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>
+    body { margin:0; font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; background:#0b0b12; color:#e8e8f0; }
+    header { padding:16px 20px; border-bottom:1px solid #1d1d2a; }
+    .fractal-controls { display:flex; gap:12px; align-items:center; }
+    select, button { padding:6px 10px; background:#1d1d2a; color:#e8e8f0; border:1px solid #3a3a4f; border-radius:4px; }
+    select:focus, button:focus { outline:2px solid #7c4dff; }
+    #fractal-status { margin-top:8px; font-size:12px; color:#a6a6c1; }
+    canvas { display:block; width:100vw; height:100vh; }
+  </style>
+</head>
+<body>
+  <header>
+    <div class="fractal-controls">
+      <label for="fractal-select">Fractal Lens</label>
+      <select id="fractal-select" onchange="loadFractal(this.value)">
+        <option value="soyga">Liber Soygæ (John Dee)</option>
+        <option value="iching">I Ching Hexagram</option>
+        <option value="kabbalah">Tree of Life</option>
+        <option value="astrology">Evolutionary Astrology</option>
+        <option value="noetics">Noetic Coherence</option>
+        <option value="biogeometrics">Earth Grid</option>
+        <option value="raku_reiki">Raku Fusion Reiki</option>
+      </select>
+      <button type="button" onclick="playReikiTone()">Play Raku Tone (963 Hz)</button>
+    </div>
+    <div id="fractal-status">Loading fractal presets…</div>
+  </header>
+
+  <canvas id="fractal-canvas" width="1280" height="720" aria-label="Fractal synthesis canvas"></canvas>
+
+  <script type="module">
+    import { renderSoyga } from "./fractals/soyga.js";
+    import { renderIChing } from "./fractals/iching.js";
+    import { renderKabbalah } from "./fractals/kabbalah.js";
+    import { renderAstrology } from "./fractals/astrology.js";
+    import { renderNoetics } from "./fractals/noetics.js";
+    import { renderBiogeometrics } from "./fractals/biogeometrics.js";
+    import { renderRakuReiki } from "./fractals/reiki.js";
+    import { playReikiTone as triggerTone } from "./harmonics/player.js";
+
+    const canvas = document.getElementById("fractal-canvas");
+    const ctx = canvas.getContext("2d");
+    const statusEl = document.getElementById("fractal-status");
+
+    const defaultPresets = {
+      soyga: {
+        name: "Liber Soygæ",
+        tradition: "John Dee",
+        type: "grid",
+        params: { size: 36, seed: "A", iterations: 7 }
+      },
+      iching: {
+        name: "I Ching Hexagram",
+        tradition: "King Wen",
+        type: "binary_tree",
+        params: { hexagram: 1, depth: 6 }
+      },
+      kabbalah: {
+        name: "Tree of Life",
+        tradition: "Hermetic Qabalah",
+        type: "graph",
+        params: { sephiroth: 10, paths: 22 }
+      },
+      astrology: {
+        name: "Evolutionary Orbs",
+        tradition: "Steven Forrest",
+        type: "orbital",
+        params: { bodies: 12, resonance: 0.618 }
+      },
+      noetics: {
+        name: "Noetic Coherence Field",
+        tradition: "IONS",
+        type: "interference",
+        params: { frequency: 7.83, coherence: 0.9 }
+      },
+      biogeometrics: {
+        name: "Earth Grid Harmonics",
+        tradition: "Bruce Cathie",
+        type: "lattice",
+        params: { grid: "666", harmonic: 144 }
+      },
+      raku_reiki: {
+        name: "Raku Fusion Flow",
+        tradition: "Raku Reiki + Shamanism",
+        type: "energy_field",
+        params: { chakras: 7, shamanic_layers: 3 }
+      }
+    };
+
+    const renderers = {
+      soyga: renderSoyga,
+      iching: renderIChing,
+      kabbalah: renderKabbalah,
+      astrology: renderAstrology,
+      noetics: renderNoetics,
+      biogeometrics: renderBiogeometrics,
+      raku_reiki: renderRakuReiki
+    };
+
+    let activePresets = defaultPresets;
+    let currentType = "raku_reiki";
+
+    function resizeCanvas() {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    }
+
+    async function loadPresets() {
+      try {
+        const res = await fetch("./data/fractal_presets.json", { cache: "no-store" });
+        if (!res.ok) {
+          throw new Error(String(res.status));
+        }
+        const json = await res.json();
+        activePresets = { ...defaultPresets, ...json };
+        statusEl.textContent = "Fractal presets loaded.";
+      } catch (error) {
+        activePresets = defaultPresets;
+        statusEl.textContent = "Presets missing; using built-in set.";
+      }
+    }
+
+    function drawFractal(type) {
+      const renderer = renderers[type];
+      if (!renderer) {
+        statusEl.textContent = "Renderer unavailable for " + type + ".";
+        return;
+      }
+      const preset = activePresets[type] || defaultPresets[type];
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const params = preset && preset.params ? preset.params : {};
+      renderer(ctx, params);
+      const label = preset && (preset.name || preset.type) ? preset.name || preset.type : type;
+      statusEl.textContent = "Showing " + label + " lens.";
+    }
+
+    window.loadFractal = (type) => {
+      currentType = type;
+      drawFractal(type);
+    };
+
+    window.playReikiTone = () => {
+      triggerTone(963, 4);
+    };
+
+    window.addEventListener("resize", () => {
+      resizeCanvas();
+      drawFractal(currentType);
+    });
+
+    resizeCanvas();
+    await loadPresets();
+    drawFractal(currentType);
+  </script>
+</body>
+</html>

--- a/data/fractal_presets.json
+++ b/data/fractal_presets.json
@@ -1,0 +1,44 @@
+{
+  "soyga": {
+    "name": "Liber Soygæ",
+    "tradition": "John Dee",
+    "type": "grid",
+    "params": { "size": 36, "seed": "A", "iterations": 7 }
+  },
+  "iching": {
+    "name": "I Ching Hexagram",
+    "tradition": "King Wen",
+    "type": "binary_tree",
+    "params": { "hexagram": 1, "depth": 6 }
+  },
+  "kabbalah": {
+    "name": "Tree of Life",
+    "tradition": "Hermetic Qabalah",
+    "type": "graph",
+    "params": { "sephiroth": 10, "paths": 22 }
+  },
+  "astrology": {
+    "name": "Evolutionary Orbs",
+    "tradition": "Steven Forrest",
+    "type": "orbital",
+    "params": { "bodies": 12, "resonance": 0.618 }
+  },
+  "noetics": {
+    "name": "Noetic Coherence Field",
+    "tradition": "IONS",
+    "type": "interference",
+    "params": { "frequency": 7.83, "coherence": 0.9 }
+  },
+  "biogeometrics": {
+    "name": "Earth Grid Harmonics",
+    "tradition": "Bruce Cathie",
+    "type": "lattice",
+    "params": { "grid": "666", "harmonic": 144 }
+  },
+  "raku_reiki": {
+    "name": "Raku Fusion Flow",
+    "tradition": "Raku Reiki + Shamanism",
+    "type": "energy_field",
+    "params": { "chakras": 7, "shamanic_layers": 3 }
+  }
+}

--- a/data/nodes_144.json
+++ b/data/nodes_144.json
@@ -1,0 +1,1442 @@
+[
+  {
+    "id": 1,
+    "name": "Node 001",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 0.0,
+    "ring": 1
+  },
+  {
+    "id": 2,
+    "name": "Node 002",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 2.5,
+    "ring": 2
+  },
+  {
+    "id": 3,
+    "name": "Node 003",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 5.0,
+    "ring": 3
+  },
+  {
+    "id": 4,
+    "name": "Node 004",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 7.5,
+    "ring": 4
+  },
+  {
+    "id": 5,
+    "name": "Node 005",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 10.0,
+    "ring": 5
+  },
+  {
+    "id": 6,
+    "name": "Node 006",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 12.5,
+    "ring": 6
+  },
+  {
+    "id": 7,
+    "name": "Node 007",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 15.0,
+    "ring": 7
+  },
+  {
+    "id": 8,
+    "name": "Node 008",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 17.5,
+    "ring": 8
+  },
+  {
+    "id": 9,
+    "name": "Node 009",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 20.0,
+    "ring": 9
+  },
+  {
+    "id": 10,
+    "name": "Node 010",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 22.5,
+    "ring": 1
+  },
+  {
+    "id": 11,
+    "name": "Node 011",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 25.0,
+    "ring": 2
+  },
+  {
+    "id": 12,
+    "name": "Node 012",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 27.5,
+    "ring": 3
+  },
+  {
+    "id": 13,
+    "name": "Node 013",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 30.0,
+    "ring": 4
+  },
+  {
+    "id": 14,
+    "name": "Node 014",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 32.5,
+    "ring": 5
+  },
+  {
+    "id": 15,
+    "name": "Node 015",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 35.0,
+    "ring": 6
+  },
+  {
+    "id": 16,
+    "name": "Node 016",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 37.5,
+    "ring": 7
+  },
+  {
+    "id": 17,
+    "name": "Node 017",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 40.0,
+    "ring": 8
+  },
+  {
+    "id": 18,
+    "name": "Node 018",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 42.5,
+    "ring": 9
+  },
+  {
+    "id": 19,
+    "name": "Node 019",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 45.0,
+    "ring": 1
+  },
+  {
+    "id": 20,
+    "name": "Node 020",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 47.5,
+    "ring": 2
+  },
+  {
+    "id": 21,
+    "name": "Node 021",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 50.0,
+    "ring": 3
+  },
+  {
+    "id": 22,
+    "name": "Node 022",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 52.5,
+    "ring": 4
+  },
+  {
+    "id": 23,
+    "name": "Node 023",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 55.0,
+    "ring": 5
+  },
+  {
+    "id": 24,
+    "name": "Node 024",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 57.5,
+    "ring": 6
+  },
+  {
+    "id": 25,
+    "name": "Node 025",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 60.0,
+    "ring": 7
+  },
+  {
+    "id": 26,
+    "name": "Node 026",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 62.5,
+    "ring": 8
+  },
+  {
+    "id": 27,
+    "name": "Node 027",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 65.0,
+    "ring": 9
+  },
+  {
+    "id": 28,
+    "name": "Node 028",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 67.5,
+    "ring": 1
+  },
+  {
+    "id": 29,
+    "name": "Node 029",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 70.0,
+    "ring": 2
+  },
+  {
+    "id": 30,
+    "name": "Node 030",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 72.5,
+    "ring": 3
+  },
+  {
+    "id": 31,
+    "name": "Node 031",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 75.0,
+    "ring": 4
+  },
+  {
+    "id": 32,
+    "name": "Node 032",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 77.5,
+    "ring": 5
+  },
+  {
+    "id": 33,
+    "name": "Node 033",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 80.0,
+    "ring": 6
+  },
+  {
+    "id": 34,
+    "name": "Node 034",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 82.5,
+    "ring": 7
+  },
+  {
+    "id": 35,
+    "name": "Node 035",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 85.0,
+    "ring": 8
+  },
+  {
+    "id": 36,
+    "name": "Node 036",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 87.5,
+    "ring": 9
+  },
+  {
+    "id": 37,
+    "name": "Node 037",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 90.0,
+    "ring": 1
+  },
+  {
+    "id": 38,
+    "name": "Node 038",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 92.5,
+    "ring": 2
+  },
+  {
+    "id": 39,
+    "name": "Node 039",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 95.0,
+    "ring": 3
+  },
+  {
+    "id": 40,
+    "name": "Node 040",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 97.5,
+    "ring": 4
+  },
+  {
+    "id": 41,
+    "name": "Node 041",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 100.0,
+    "ring": 5
+  },
+  {
+    "id": 42,
+    "name": "Node 042",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 102.5,
+    "ring": 6
+  },
+  {
+    "id": 43,
+    "name": "Node 043",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 105.0,
+    "ring": 7
+  },
+  {
+    "id": 44,
+    "name": "Node 044",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 107.5,
+    "ring": 8
+  },
+  {
+    "id": 45,
+    "name": "Node 045",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 110.0,
+    "ring": 9
+  },
+  {
+    "id": 46,
+    "name": "Node 046",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 112.5,
+    "ring": 1
+  },
+  {
+    "id": 47,
+    "name": "Node 047",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 115.0,
+    "ring": 2
+  },
+  {
+    "id": 48,
+    "name": "Node 048",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 117.5,
+    "ring": 3
+  },
+  {
+    "id": 49,
+    "name": "Node 049",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 120.0,
+    "ring": 4
+  },
+  {
+    "id": 50,
+    "name": "Node 050",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 122.5,
+    "ring": 5
+  },
+  {
+    "id": 51,
+    "name": "Node 051",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 125.0,
+    "ring": 6
+  },
+  {
+    "id": 52,
+    "name": "Node 052",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 127.5,
+    "ring": 7
+  },
+  {
+    "id": 53,
+    "name": "Node 053",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 130.0,
+    "ring": 8
+  },
+  {
+    "id": 54,
+    "name": "Node 054",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 132.5,
+    "ring": 9
+  },
+  {
+    "id": 55,
+    "name": "Node 055",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 135.0,
+    "ring": 1
+  },
+  {
+    "id": 56,
+    "name": "Node 056",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 137.5,
+    "ring": 2
+  },
+  {
+    "id": 57,
+    "name": "Node 057",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 140.0,
+    "ring": 3
+  },
+  {
+    "id": 58,
+    "name": "Node 058",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 142.5,
+    "ring": 4
+  },
+  {
+    "id": 59,
+    "name": "Node 059",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 145.0,
+    "ring": 5
+  },
+  {
+    "id": 60,
+    "name": "Node 060",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 147.5,
+    "ring": 6
+  },
+  {
+    "id": 61,
+    "name": "Node 061",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 150.0,
+    "ring": 7
+  },
+  {
+    "id": 62,
+    "name": "Node 062",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 152.5,
+    "ring": 8
+  },
+  {
+    "id": 63,
+    "name": "Node 063",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 155.0,
+    "ring": 9
+  },
+  {
+    "id": 64,
+    "name": "Node 064",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 157.5,
+    "ring": 1
+  },
+  {
+    "id": 65,
+    "name": "Node 065",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 160.0,
+    "ring": 2
+  },
+  {
+    "id": 66,
+    "name": "Node 066",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 162.5,
+    "ring": 3
+  },
+  {
+    "id": 67,
+    "name": "Node 067",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 165.0,
+    "ring": 4
+  },
+  {
+    "id": 68,
+    "name": "Node 068",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 167.5,
+    "ring": 5
+  },
+  {
+    "id": 69,
+    "name": "Node 069",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 170.0,
+    "ring": 6
+  },
+  {
+    "id": 70,
+    "name": "Node 070",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 172.5,
+    "ring": 7
+  },
+  {
+    "id": 71,
+    "name": "Node 071",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 175.0,
+    "ring": 8
+  },
+  {
+    "id": 72,
+    "name": "Node 072",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 177.5,
+    "ring": 9
+  },
+  {
+    "id": 73,
+    "name": "Node 073",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 180.0,
+    "ring": 1
+  },
+  {
+    "id": 74,
+    "name": "Node 074",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 182.5,
+    "ring": 2
+  },
+  {
+    "id": 75,
+    "name": "Node 075",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 185.0,
+    "ring": 3
+  },
+  {
+    "id": 76,
+    "name": "Node 076",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 187.5,
+    "ring": 4
+  },
+  {
+    "id": 77,
+    "name": "Node 077",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 190.0,
+    "ring": 5
+  },
+  {
+    "id": 78,
+    "name": "Node 078",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 192.5,
+    "ring": 6
+  },
+  {
+    "id": 79,
+    "name": "Node 079",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 195.0,
+    "ring": 7
+  },
+  {
+    "id": 80,
+    "name": "Node 080",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 197.5,
+    "ring": 8
+  },
+  {
+    "id": 81,
+    "name": "Node 081",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 200.0,
+    "ring": 9
+  },
+  {
+    "id": 82,
+    "name": "Node 082",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 202.5,
+    "ring": 1
+  },
+  {
+    "id": 83,
+    "name": "Node 083",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 205.0,
+    "ring": 2
+  },
+  {
+    "id": 84,
+    "name": "Node 084",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 207.5,
+    "ring": 3
+  },
+  {
+    "id": 85,
+    "name": "Node 085",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 210.0,
+    "ring": 4
+  },
+  {
+    "id": 86,
+    "name": "Node 086",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 212.5,
+    "ring": 5
+  },
+  {
+    "id": 87,
+    "name": "Node 087",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 215.0,
+    "ring": 6
+  },
+  {
+    "id": 88,
+    "name": "Node 088",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 217.5,
+    "ring": 7
+  },
+  {
+    "id": 89,
+    "name": "Node 089",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 220.0,
+    "ring": 8
+  },
+  {
+    "id": 90,
+    "name": "Node 090",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 222.5,
+    "ring": 9
+  },
+  {
+    "id": 91,
+    "name": "Node 091",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 225.0,
+    "ring": 1
+  },
+  {
+    "id": 92,
+    "name": "Node 092",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 227.5,
+    "ring": 2
+  },
+  {
+    "id": 93,
+    "name": "Node 093",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 230.0,
+    "ring": 3
+  },
+  {
+    "id": 94,
+    "name": "Node 094",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 232.5,
+    "ring": 4
+  },
+  {
+    "id": 95,
+    "name": "Node 095",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 235.0,
+    "ring": 5
+  },
+  {
+    "id": 96,
+    "name": "Node 096",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 237.5,
+    "ring": 6
+  },
+  {
+    "id": 97,
+    "name": "Node 097",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 240.0,
+    "ring": 7
+  },
+  {
+    "id": 98,
+    "name": "Node 098",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 242.5,
+    "ring": 8
+  },
+  {
+    "id": 99,
+    "name": "Node 099",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 245.0,
+    "ring": 9
+  },
+  {
+    "id": 100,
+    "name": "Node 100",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 247.5,
+    "ring": 1
+  },
+  {
+    "id": 101,
+    "name": "Node 101",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 250.0,
+    "ring": 2
+  },
+  {
+    "id": 102,
+    "name": "Node 102",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 252.5,
+    "ring": 3
+  },
+  {
+    "id": 103,
+    "name": "Node 103",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 255.0,
+    "ring": 4
+  },
+  {
+    "id": 104,
+    "name": "Node 104",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 257.5,
+    "ring": 5
+  },
+  {
+    "id": 105,
+    "name": "Node 105",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 260.0,
+    "ring": 6
+  },
+  {
+    "id": 106,
+    "name": "Node 106",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 262.5,
+    "ring": 7
+  },
+  {
+    "id": 107,
+    "name": "Node 107",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 265.0,
+    "ring": 8
+  },
+  {
+    "id": 108,
+    "name": "Node 108",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 267.5,
+    "ring": 9
+  },
+  {
+    "id": 109,
+    "name": "Node 109",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 270.0,
+    "ring": 1
+  },
+  {
+    "id": 110,
+    "name": "Node 110",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 272.5,
+    "ring": 2
+  },
+  {
+    "id": 111,
+    "name": "Node 111",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 275.0,
+    "ring": 3
+  },
+  {
+    "id": 112,
+    "name": "Node 112",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 277.5,
+    "ring": 4
+  },
+  {
+    "id": 113,
+    "name": "Node 113",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 280.0,
+    "ring": 5
+  },
+  {
+    "id": 114,
+    "name": "Node 114",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 282.5,
+    "ring": 6
+  },
+  {
+    "id": 115,
+    "name": "Node 115",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 285.0,
+    "ring": 7
+  },
+  {
+    "id": 116,
+    "name": "Node 116",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 287.5,
+    "ring": 8
+  },
+  {
+    "id": 117,
+    "name": "Node 117",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 290.0,
+    "ring": 9
+  },
+  {
+    "id": 118,
+    "name": "Node 118",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 292.5,
+    "ring": 1
+  },
+  {
+    "id": 119,
+    "name": "Node 119",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 295.0,
+    "ring": 2
+  },
+  {
+    "id": 120,
+    "name": "Node 120",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 297.5,
+    "ring": 3
+  },
+  {
+    "id": 121,
+    "name": "Node 121",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 300.0,
+    "ring": 4
+  },
+  {
+    "id": 122,
+    "name": "Node 122",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 302.5,
+    "ring": 5
+  },
+  {
+    "id": 123,
+    "name": "Node 123",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 305.0,
+    "ring": 6
+  },
+  {
+    "id": 124,
+    "name": "Node 124",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 307.5,
+    "ring": 7
+  },
+  {
+    "id": 125,
+    "name": "Node 125",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 310.0,
+    "ring": 8
+  },
+  {
+    "id": 126,
+    "name": "Node 126",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 312.5,
+    "ring": 9
+  },
+  {
+    "id": 127,
+    "name": "Node 127",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 315.0,
+    "ring": 1
+  },
+  {
+    "id": 128,
+    "name": "Node 128",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 317.5,
+    "ring": 2
+  },
+  {
+    "id": 129,
+    "name": "Node 129",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 320.0,
+    "ring": 3
+  },
+  {
+    "id": 130,
+    "name": "Node 130",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 322.5,
+    "ring": 4
+  },
+  {
+    "id": 131,
+    "name": "Node 131",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 325.0,
+    "ring": 5
+  },
+  {
+    "id": 132,
+    "name": "Node 132",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 327.5,
+    "ring": 6
+  },
+  {
+    "id": 133,
+    "name": "Node 133",
+    "hall": "Fool",
+    "traditions": [
+      "Alchemy"
+    ],
+    "angle_deg": 330.0,
+    "ring": 7
+  },
+  {
+    "id": 134,
+    "name": "Node 134",
+    "hall": "Magus",
+    "traditions": [
+      "Hermetic"
+    ],
+    "angle_deg": 332.5,
+    "ring": 8
+  },
+  {
+    "id": 135,
+    "name": "Node 135",
+    "hall": "Empress",
+    "traditions": [
+      "Noetic"
+    ],
+    "angle_deg": 335.0,
+    "ring": 9
+  },
+  {
+    "id": 136,
+    "name": "Node 136",
+    "hall": "Emperor",
+    "traditions": [
+      "Astrology"
+    ],
+    "angle_deg": 337.5,
+    "ring": 1
+  },
+  {
+    "id": 137,
+    "name": "Node 137",
+    "hall": "Hierophant",
+    "traditions": [
+      "Geomancy"
+    ],
+    "angle_deg": 340.0,
+    "ring": 2
+  },
+  {
+    "id": 138,
+    "name": "Node 138",
+    "hall": "Lovers",
+    "traditions": [
+      "Tarot"
+    ],
+    "angle_deg": 342.5,
+    "ring": 3
+  },
+  {
+    "id": 139,
+    "name": "Node 139",
+    "hall": "Chariot",
+    "traditions": [
+      "Runic"
+    ],
+    "angle_deg": 345.0,
+    "ring": 4
+  },
+  {
+    "id": 140,
+    "name": "Node 140",
+    "hall": "Strength",
+    "traditions": [
+      "Gnostic"
+    ],
+    "angle_deg": 347.5,
+    "ring": 5
+  },
+  {
+    "id": 141,
+    "name": "Node 141",
+    "hall": "Hermit",
+    "traditions": [
+      "Tantric"
+    ],
+    "angle_deg": 350.0,
+    "ring": 6
+  },
+  {
+    "id": 142,
+    "name": "Node 142",
+    "hall": "Wheel",
+    "traditions": [
+      "Dreamwork"
+    ],
+    "angle_deg": 352.5,
+    "ring": 7
+  },
+  {
+    "id": 143,
+    "name": "Node 143",
+    "hall": "Justice",
+    "traditions": [
+      "Mythic"
+    ],
+    "angle_deg": 355.0,
+    "ring": 8
+  },
+  {
+    "id": 144,
+    "name": "Node 144",
+    "hall": "Hanged Man",
+    "traditions": [
+      "Sound"
+    ],
+    "angle_deg": 357.5,
+    "ring": 9
+  }
+]

--- a/data/octagram_halls.json
+++ b/data/octagram_halls.json
@@ -1,0 +1,10 @@
+[
+  {"id": 1, "name": "Fool", "element": "Air", "focus": "Innocent emergence", "constellation": "Aquila"},
+  {"id": 2, "name": "Magus", "element": "Mercury", "focus": "Words as spells", "constellation": "Orion"},
+  {"id": 3, "name": "Tower", "element": "Mars", "focus": "Liberating disruption", "constellation": "Scorpius"},
+  {"id": 4, "name": "Moon", "element": "Water", "focus": "Dream tides", "constellation": "Lyra"},
+  {"id": 5, "name": "Star", "element": "Ether", "focus": "Guiding resonance", "constellation": "Pleiades"},
+  {"id": 6, "name": "Sun", "element": "Solar", "focus": "Radiant coherence", "constellation": "Leo"},
+  {"id": 7, "name": "World", "element": "Earth", "focus": "Embodied wholeness", "constellation": "Ursa Minor"},
+  {"id": 8, "name": "Aeon", "element": "Chronos", "focus": "Trans-temporal insight", "constellation": "Cygnus"}
+]

--- a/fractals/astrology.js
+++ b/fractals/astrology.js
@@ -1,0 +1,26 @@
+// Evolutionary astrology orbits: concentric bands with gentle resonant arcs.
+export function renderAstrology(ctx, params = {}) {
+  const { bodies = 12, resonance = 0.618 } = params;
+  const { width, height } = ctx.canvas;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const maxRadius = Math.min(centerX, centerY) * 0.85;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  for (let i = 1; i <= bodies; i += 1) {
+    const ratio = i / bodies;
+    const radius = maxRadius * ratio;
+    ctx.strokeStyle = i % 2 === 0 ? "#89f7fe" : "#ffd27f";
+    ctx.lineWidth = i % 3 === 0 ? 2 : 1;
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    const arcLength = resonance * Math.PI;
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, -arcLength, arcLength);
+    ctx.stroke();
+  }
+}

--- a/fractals/biogeometrics.js
+++ b/fractals/biogeometrics.js
@@ -1,0 +1,43 @@
+// Biogeometrics lattice: static earth grid harmonics, no flashing lines.
+export function renderBiogeometrics(ctx, params = {}) {
+  const { grid = "666", harmonic = 144 } = params;
+  const { width, height } = ctx.canvas;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  const divisions = parseInt(grid, 10) || 6;
+  const spacingX = width / divisions;
+  const spacingY = height / divisions;
+
+  ctx.strokeStyle = "#b1c7ff";
+  ctx.lineWidth = 1;
+  for (let i = 0; i <= divisions; i += 1) {
+    const x = i * spacingX;
+    ctx.beginPath();
+    ctx.moveTo(x, 0);
+    ctx.lineTo(x, height);
+    ctx.stroke();
+  }
+
+  for (let j = 0; j <= divisions; j += 1) {
+    const y = j * spacingY;
+    ctx.beginPath();
+    ctx.moveTo(0, y);
+    ctx.lineTo(width, y);
+    ctx.stroke();
+  }
+
+  ctx.strokeStyle = "#ffd27f";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, 0);
+  ctx.lineTo(width, height);
+  ctx.moveTo(width, 0);
+  ctx.lineTo(0, height);
+  ctx.stroke();
+
+  ctx.fillStyle = "#a0ffa1";
+  ctx.font = "16px monospace";
+  ctx.fillText(`Harmonic ${harmonic}`, 12, height - 16);
+}

--- a/fractals/iching.js
+++ b/fractals/iching.js
@@ -1,0 +1,34 @@
+// I Ching renderer: static radial hexagram lines, no motion for ND safety.
+export function renderIChing(ctx, params = {}) {
+  const { hexagram = 1, depth = 6 } = params;
+  const { width, height } = ctx.canvas;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const radius = Math.min(centerX, centerY) * 0.75;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  const lines = hexagramToLines(hexagram);
+  lines.forEach((line, index) => {
+    const angle = (index / depth) * Math.PI * 2 - Math.PI / 2;
+    const lineRadius = radius * (1 - index / depth);
+    const x1 = centerX + Math.cos(angle) * lineRadius;
+    const y1 = centerY + Math.sin(angle) * lineRadius;
+    const x2 = centerX - Math.cos(angle) * lineRadius;
+    const y2 = centerY - Math.sin(angle) * lineRadius;
+
+    ctx.strokeStyle = line === 1 ? "#d4af37" : "#7c4dff";
+    ctx.lineWidth = line === 1 ? 4 : 2;
+    ctx.beginPath();
+    ctx.moveTo(x1, y1);
+    ctx.lineTo(x2, y2);
+    ctx.stroke();
+  });
+}
+
+function hexagramToLines(hexagram) {
+  const value = Math.max(1, Math.min(64, Math.floor(hexagram)));
+  const binary = (value - 1).toString(2).padStart(6, "0");
+  return [...binary].map((bit) => (bit === "1" ? 1 : 0));
+}

--- a/fractals/kabbalah.js
+++ b/fractals/kabbalah.js
@@ -1,0 +1,55 @@
+// Tree of Life renderer: static paths and sephiroth for grounded depth.
+export function renderKabbalah(ctx, params = {}) {
+  const { sephiroth = 10 } = params;
+  const { width, height } = ctx.canvas;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  const positions = basePositions().slice(0, sephiroth);
+  drawPaths(ctx, positions);
+  drawNodes(ctx, positions);
+}
+
+function basePositions() {
+  return [
+    [0.5, 0.08],
+    [0.35, 0.2],
+    [0.65, 0.2],
+    [0.5, 0.32],
+    [0.25, 0.45],
+    [0.75, 0.45],
+    [0.5, 0.58],
+    [0.25, 0.72],
+    [0.75, 0.72],
+    [0.5, 0.88]
+  ];
+}
+
+function drawPaths(ctx, positions) {
+  const paths = [
+    [0, 1], [0, 2], [1, 2], [1, 4], [2, 5], [4, 6], [5, 6], [6, 7], [6, 8], [7, 9], [8, 9]
+  ];
+  ctx.strokeStyle = "#7c4dff";
+  ctx.lineWidth = 2;
+  paths.forEach(([a, b]) => {
+    if (!positions[a] || !positions[b]) {
+      return;
+    }
+    const [ax, ay] = positions[a];
+    const [bx, by] = positions[b];
+    ctx.beginPath();
+    ctx.moveTo(ax * ctx.canvas.width, ay * ctx.canvas.height);
+    ctx.lineTo(bx * ctx.canvas.width, by * ctx.canvas.height);
+    ctx.stroke();
+  });
+}
+
+function drawNodes(ctx, positions) {
+  ctx.fillStyle = "#d4af37";
+  positions.forEach(([x, y]) => {
+    ctx.beginPath();
+    ctx.arc(x * ctx.canvas.width, y * ctx.canvas.height, 10, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}

--- a/fractals/noetics.js
+++ b/fractals/noetics.js
@@ -1,0 +1,26 @@
+// Noetic coherence: layered interference circles marking Schumann resonance.
+export function renderNoetics(ctx, params = {}) {
+  const { frequency = 7.83, coherence = 0.9 } = params;
+  const { width, height } = ctx.canvas;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const baseRadius = Math.min(centerX, centerY) * 0.6;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  const rings = Math.round(coherence * 11) || 1;
+  for (let i = 0; i < rings; i += 1) {
+    const radius = baseRadius * (1 + i * 0.12);
+    ctx.strokeStyle = i % 2 === 0 ? "#a0ffa1" : "#f5a3ff";
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.arc(centerX, centerY, radius, 0, Math.PI * 2);
+    ctx.stroke();
+
+    const offset = (i + 1) * frequency * 0.01;
+    ctx.beginPath();
+    ctx.arc(centerX + offset * 20, centerY - offset * 10, radius * 0.85, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}

--- a/fractals/reiki.js
+++ b/fractals/reiki.js
@@ -1,0 +1,39 @@
+// Raku Reiki renderer: spiral traces only, no pulsing animation.
+export function renderRakuReiki(ctx, params = {}) {
+  const { chakras = 7, shamanic_layers = 3 } = params;
+  const { width, height } = ctx.canvas;
+  const centerX = width / 2;
+  const centerY = height / 2;
+  const maxRadius = Math.min(centerX, centerY) * 0.9;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, width, height);
+
+  const colors = [
+    "#ff0000", "#ff7f00", "#ffff00", "#00ff00", "#0000ff", "#4b0082", "#9400d3"
+  ];
+
+  for (let i = 0; i < chakras; i += 1) {
+    const radius = maxRadius * (i + 1) / chakras;
+    const color = colors[i] || "#d4af37";
+    const alpha = 0.3 + (i / Math.max(1, chakras)) * 0.4;
+
+    ctx.strokeStyle = color;
+    ctx.globalAlpha = alpha;
+    ctx.lineWidth = shamanic_layers;
+    ctx.beginPath();
+    for (let angle = 0; angle <= Math.PI * 4; angle += 0.1) {
+      const spiralRadius = radius * (angle / (Math.PI * 4));
+      const x = centerX + Math.cos(angle) * spiralRadius;
+      const y = centerY + Math.sin(angle) * spiralRadius;
+      if (angle === 0) {
+        ctx.moveTo(x, y);
+      } else {
+        ctx.lineTo(x, y);
+      }
+    }
+    ctx.stroke();
+  }
+
+  ctx.globalAlpha = 1;
+}

--- a/fractals/soyga.js
+++ b/fractals/soyga.js
@@ -1,0 +1,22 @@
+// Soyga grid renderer: static character lattice, no animation (ND-safe).
+export function renderSoyga(ctx, params = {}) {
+  const { size = 36, seed = "A", iterations = 7 } = params;
+  const side = Math.min(ctx.canvas.width, ctx.canvas.height);
+  const cellSize = side / size;
+
+  ctx.fillStyle = "#0b0b12";
+  ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+
+  ctx.fillStyle = "#d4af37";
+  ctx.font = `${cellSize * 0.6}px monospace`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "middle";
+
+  for (let y = 0; y < size; y += 1) {
+    for (let x = 0; x < size; x += 1) {
+      const charIndex = (x * iterations + y + seed.charCodeAt(0)) % 26;
+      const char = String.fromCharCode(65 + charIndex);
+      ctx.fillText(char, x * cellSize + cellSize / 2, y * cellSize + cellSize / 2);
+    }
+  }
+}

--- a/harmonics/player.js
+++ b/harmonics/player.js
@@ -1,0 +1,28 @@
+// Simple Web Audio player for Solfeggio and Reiki tones (static trigger only).
+let audioContext;
+
+export function playReikiTone(frequency = 963, durationSeconds = 3) {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (!audioContext) {
+    const AudioContextClass = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextClass) {
+      return;
+    }
+    audioContext = new AudioContextClass();
+  }
+
+  const oscillator = audioContext.createOscillator();
+  const gain = audioContext.createGain();
+
+  oscillator.type = "sine";
+  oscillator.frequency.value = frequency;
+  gain.gain.value = 0.2;
+
+  oscillator.connect(gain);
+  gain.connect(audioContext.destination);
+
+  oscillator.start();
+  oscillator.stop(audioContext.currentTime + durationSeconds);
+}


### PR DESCRIPTION
## Summary
- add fractal preset and cosmology data files for the fractal synthesis engine
- implement renderer modules for each fractal tradition and a Reiki tone player
- create the Codex14499 interface with fractal selection, fallback presets, and tone playback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d694de72f48328b3548ab6c086710b