### PR TITLE
Clean up duplicate Cosmic Helix renderer content

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -9,10 +9,6 @@ Static HTML + Canvas renderer that honors the Cosmic-Helix spec with layered geo
 - `data/palette.json` - editable ND-safe palette. If missing, the renderer falls back to embedded colors and paints a gentle inline notice.
 - `data/palettes/` - optional curated palettes to copy over `data/palette.json`.
 
-- `index.html` – entry point with a 1440x900 canvas, palette loader, and ND-safe status copy.
-- `js/helix-renderer.mjs` – pure ES module that draws the Vesica field, Tree-of-Life scaffold, Fibonacci curve, and static double-helix lattice in that order.
-- `data/palette.json` – editable palette file. Remove it to test the inline fallback notice; the renderer stays safe.
-
 ## Rendered Layers
 1. **Vesica field** – Seven by nine circle lattice using constants 7 and 9 for grounding repetition.
 2. **Tree-of-Life scaffold** – Ten sephirot nodes with twenty-two connective paths. Layout ratios weave constants 3, 7, 9, 11, 22, 33, 99, and 144.

--- a/index.html
+++ b/index.html
@@ -18,13 +18,8 @@
 </head>
 <body>
   <header>
-
-    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Preparing canvas...</div>
-
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
     <div class="status" id="status">Preparing canvas…</div>
-
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -39,7 +34,6 @@
 
     if (!ctx) {
       statusEl.textContent = "Canvas unsupported in this browser.";
-
     } else {
       const DEFAULTS = Object.freeze({
         palette: {
@@ -93,59 +87,6 @@
         });
       })();
     }
-
-      throw new Error("Canvas context unavailable");
-    }
-
-    const DEFAULTS = Object.freeze({
-      palette: {
-        // ND-safe fallback colors keep contrast gentle when palette.json is absent.
-        bg: "#0b0b12",
-        ink: "#e8e8f0",
-        layers: ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
-      }
-    });
-
-    async function loadJSON(path) {
-      // ND-safe: local fetch only; when file:// blocks it, we quietly fall back to the embedded palette.
-      try {
-        const response = await fetch(path, { cache: "no-store" });
-        if (!response.ok) {
-          throw new Error(String(response.status));
-        }
-        return await response.json();
-      } catch (error) {
-        return null;
-      }
-    }
-
-    const palette = await loadJSON("./data/palette.json");
-    const activePalette = palette || DEFAULTS.palette;
-    statusEl.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
-    // Harmonise document colors with the palette so the canvas sits in a matching field.
-    document.documentElement.style.setProperty("--bg", activePalette.bg || DEFAULTS.palette.bg);
-    document.documentElement.style.setProperty("--ink", activePalette.ink || DEFAULTS.palette.ink);
-
-    const NUM = Object.freeze({
-      THREE: 3,
-      SEVEN: 7,
-      NINE: 9,
-      ELEVEN: 11,
-      TWENTYTWO: 22,
-      THIRTYTHREE: 33,
-      NINETYNINE: 99,
-      ONEFORTYFOUR: 144
-    });
-
-    // ND-safe rationale: no motion, high readability, soft colors, layered order.
-    renderHelix(ctx, {
-      width: canvas.width,
-      height: canvas.height,
-      palette: activePalette,
-      NUM,
-      missingPalette: !palette
-    });
 
   </script>
 </body>


### PR DESCRIPTION
## Summary
- remove duplicate status/header markup and redundant script block in the Cosmic Helix renderer index page
- deduplicate repeated file listings in README_RENDERER for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ccdb071c83288d535f1b7f896ca1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated file references from README_RENDERER to reflect current project structure.

* **Refactor**
  * Simplified index page initialization: deduplicated header content, streamlined palette loading into a single async flow with inline defaults, and removed redundant fallback and helper code.
  * Cleaned up handling for missing canvas context without altering behavior.

* **Chores**
  * General housekeeping to reduce duplication and improve maintainability with no changes to functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->